### PR TITLE
Disable wallet popup on invite link creation page

### DIFF
--- a/src/app/providers/Web3Provider.tsx
+++ b/src/app/providers/Web3Provider.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { PrivyProvider } from "@privy-io/react-auth";
 import { WagmiProvider } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
 import { gnosis } from "viem/chains";
 import { http, createConfig, WagmiProvider as BaseWagmiProvider } from "wagmi";
 
@@ -21,6 +22,9 @@ const queryClient = new QueryClient();
 const privyAppId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
 
 export function Web3Provider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const disableWalletUIs = pathname === "/new";
+
   if (!privyAppId) {
     console.warn("NEXT_PUBLIC_PRIVY_APP_ID is not set");
     return (
@@ -44,6 +48,7 @@ export function Web3Provider({ children }: { children: React.ReactNode }) {
           ethereum: {
             createOnLogin: "users-without-wallets",
           },
+          showWalletUIs: !disableWalletUIs,
         },
         defaultChain: gnosis,
         supportedChains: [gnosis],


### PR DESCRIPTION
## Summary
- Conditionally disables wallet UIs when user is on the `/new` (invite link creation) page
- Uses `usePathname` hook to detect route and set `showWalletUIs: false` on embedded wallets

## Test plan
- [ ] Navigate to `/new` and verify wallet popup doesn't appear
- [ ] Navigate to other pages and verify wallet functionality works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)