### PR TITLE
Chore/update submodules dev deploy

### DIFF
--- a/makefile
+++ b/makefile
@@ -79,6 +79,14 @@ update-env:
 	@echo "✓ Updated .env.local successfully with contract addresses and creation block $(CREATION_BLOCK)"
 
 update-contract-submodules:
+	@# Recover from broken saving-circles submodule state (e.g. HEAD -> refs/heads/.invalid)
+	@if [ -f .git/modules/contracts/lib/saving-circles/HEAD ] && \
+		grep -q "refs/heads/.invalid" .git/modules/contracts/lib/saving-circles/HEAD; then \
+		echo "Detected invalid saving-circles submodule HEAD; reinitializing..."; \
+		git submodule deinit -f contracts/lib/saving-circles; \
+		rm -rf .git/modules/contracts/lib/saving-circles; \
+		rm -rf contracts/lib/saving-circles; \
+	fi
 	git submodule sync --recursive && \
 	git submodule update --init --recursive && \
 	git submodule update --remote --merge && \

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy anvil update-env update-contract-submodules warp time-increase mine timestamp time-reset
+.PHONY: deploy anvil update-env update-contract-submodules update-saving-circles-dev warp time-increase mine timestamp time-reset
 
 ANVIL_ACCOUNTS := 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
 	0x70997970C51812dc3A010C7d01b50e0d17dc79C8 \
@@ -81,7 +81,16 @@ update-env:
 update-contract-submodules:
 	git submodule sync --recursive && \
 	git submodule update --init --recursive && \
-	git submodule update --remote --merge
+	git submodule update --remote --merge && \
+	git -C contracts/lib/saving-circles fetch origin dev && \
+	git -C contracts/lib/saving-circles checkout dev && \
+	git -C contracts/lib/saving-circles pull --ff-only origin dev
+
+update-saving-circles-dev:
+	git submodule update --init contracts/lib/saving-circles && \
+	git -C contracts/lib/saving-circles fetch origin dev && \
+	git -C contracts/lib/saving-circles checkout dev && \
+	git -C contracts/lib/saving-circles pull --ff-only origin dev
 
 # Time manipulation commands for Anvil
 mine:


### PR DESCRIPTION
## Summary
This PR improves the submodule update workflow in `makefile` to make local setup and deploy more reliable.

## Changes
- Updates `update-contract-submodules` to also move `contracts/lib/saving-circles` to the latest `origin/dev`.
- Adds recovery logic for a broken `saving-circles` submodule state (invalid HEAD), automatically reinitializing it before continuing.
- Adds a dedicated helper target `update-saving-circles-dev` to refresh only that submodule.

## Why
Some local environments were failing during deploy because:
- submodules were not fully initialized, or
- `saving-circles` was in a corrupted submodule state (`No such ref: HEAD`).

This ensures `make update-contract-submodules` is enough to recover and align dependencies without manual git cleanup steps.

## Validation
- Verified `make` parsing (`make -n update-contract-submodules`).
- Confirmed target now includes submodule sync/init/update, self-heal path for invalid HEAD, and `saving-circles` fast-forward on `dev`.