### PR TITLE
stabilize Privy tx flow, harden deploy targets, and align stack round UI

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy anvil update-env update-contract-submodules update-saving-circles-dev warp time-increase mine timestamp time-reset
+.PHONY: deploy install-contract-deps anvil update-env update-contract-submodules update-saving-circles-dev warp time-increase mine timestamp time-reset
 
 ANVIL_ACCOUNTS := 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
 	0x70997970C51812dc3A010C7d01b50e0d17dc79C8 \
@@ -17,6 +17,8 @@ RPC_URL ?= http://localhost:8545
 PRIVATE_KEY ?= 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ADMIN_ADDRESS ?= 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 OZ_UPGRADEABLE_REENTRANCY_COMMIT ?= 5c4c29275d02e06265ce1cfcad5a420b58a5ca02
+SAVING_CIRCLES_BRANCH ?= feat/member-withdrawable-view
+SOLC_OPTIMIZER_RUNS ?= 200
 
 anvil:
 	anvil --fork-url https://rpc.gnosischain.com --chain-id 31337 --block-time 5
@@ -33,13 +35,17 @@ reset-nonces:
 	done
 	@echo "✓ All nonces reset successfully"
 
+install-contract-deps:
+	cd contracts && forge install
+
 deploy:
 	cd contracts && \
 	export RPC_URL=$(RPC_URL) && \
 	export PRIVATE_KEY=$(PRIVATE_KEY) && \
 	export ADMIN_ADDRESS=$(ADMIN_ADDRESS) && \
-	forge install && \
 	forge script script/Deploy.s.sol:Deploy \
+		--optimize \
+		--optimizer-runs $(SOLC_OPTIMIZER_RUNS) \
 		--rpc-url $(RPC_URL) \
 		--broadcast \
 		--private-key $(PRIVATE_KEY) \
@@ -103,15 +109,15 @@ update-contract-submodules:
 	git -C contracts/lib/openzeppelin-contracts-upgradeable checkout $(OZ_UPGRADEABLE_REENTRANCY_COMMIT)
 	@test -f contracts/lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol || \
 		( echo "Error: missing contracts/lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol after checkout $(OZ_UPGRADEABLE_REENTRANCY_COMMIT)"; exit 1 )
-	git -C contracts/lib/saving-circles fetch origin dev && \
-	git -C contracts/lib/saving-circles checkout dev && \
-	git -C contracts/lib/saving-circles pull --ff-only origin dev
+	git -C contracts/lib/saving-circles fetch origin $(SAVING_CIRCLES_BRANCH) && \
+	git -C contracts/lib/saving-circles checkout $(SAVING_CIRCLES_BRANCH) && \
+	git -C contracts/lib/saving-circles pull --ff-only origin $(SAVING_CIRCLES_BRANCH)
 
 update-saving-circles-dev:
 	git submodule update --init contracts/lib/saving-circles && \
-	git -C contracts/lib/saving-circles fetch origin dev && \
-	git -C contracts/lib/saving-circles checkout dev && \
-	git -C contracts/lib/saving-circles pull --ff-only origin dev
+	git -C contracts/lib/saving-circles fetch origin $(SAVING_CIRCLES_BRANCH) && \
+	git -C contracts/lib/saving-circles checkout $(SAVING_CIRCLES_BRANCH) && \
+	git -C contracts/lib/saving-circles pull --ff-only origin $(SAVING_CIRCLES_BRANCH)
 
 # Time manipulation commands for Anvil
 mine:

--- a/src/app/new/_components/form/overview.tsx
+++ b/src/app/new/_components/form/overview.tsx
@@ -124,7 +124,7 @@ const StackOverviewForm = ({ onBack }: { onBack: () => void }) => {
           -2
         )}${data.members === 1 ? "" : "s"}`.trim(),
         deposit: data.depositAmount,
-        total: data.members * data.depositAmount,
+        total: data.members ** 2 * data.depositAmount,
         members: data.members,
       };
 
@@ -140,7 +140,8 @@ const StackOverviewForm = ({ onBack }: { onBack: () => void }) => {
         ...localCircles,
         [circle.id]: {
           name: circle.name,
-          owner: user.address, // Store the owner for reference
+          owner: user.address,
+          totalMembers: data.members,
         },
       };
       localStorage.setItem("circles", JSON.stringify(localCircles));

--- a/src/app/stacks/[id]/_components/days-left.tsx
+++ b/src/app/stacks/[id]/_components/days-left.tsx
@@ -55,7 +55,7 @@ const DaysLeft = ({
       <div>
         <div className="flex items-center justify-start gap-0.5">
           <CalendarStarIcon size={24} className="fill-blue-2" />
-          <Body>Days left until next round</Body>
+          <Body>Days left until current round ends</Body>
         </div>
         <p className="text-h2 text-2xl leading-6 mt-2">{daysLeft}</p>
       </div>

--- a/src/app/stacks/[id]/_components/overview.tsx
+++ b/src/app/stacks/[id]/_components/overview.tsx
@@ -18,6 +18,8 @@ import { useCircleStatus } from "@/hooks/use-circle-status";
 import StartCircleButton from "@/components/start-circle-button";
 import DepositButton from "@/components/deposit-button";
 import { useModal } from "@/components/modal/context";
+import { useEffect, useState } from "react";
+import { LocalStorageCircles } from "@/interfaces/circle";
 
 const Overview = ({
   circle,
@@ -33,18 +35,33 @@ const Overview = ({
 }) => {
   const { setModal } = useModal();
   const connectedUser = useConnectedUser();
+  const [totalMembers, setTotalMembers] = useState<string | number>(0);
   const formattedCircleStatus = getUserCircleStatus(circle, member, {
     includeClaimable: true,
     // includeDeposited: true,
   });
-  const totalMembers = Number(circle.totalRounds);
+
+  useEffect(() => {
+    if (formattedCircleStatus.status === "pending-start") {
+      const localCircles: LocalStorageCircles = JSON.parse(
+        localStorage.getItem("circles") || "{}"
+      );
+
+      const localCircle = localCircles[circle.circleId.toString()];
+
+      setTotalMembers(localCircle?.totalMembers || "-");
+    } else {
+      setTotalMembers(Number(circle.totalRounds));
+    }
+  }, []);
+
   let roundsCompleted = BigInt(0);
   let membersDeposited: bigint | number = BigInt(0);
   let poolBalance = BigInt(0);
 
   if (formattedCircleStatus.status === "finished") {
     roundsCompleted = circle.totalRounds;
-    membersDeposited = totalMembers;
+    membersDeposited = totalMembers as number;
     poolBalance = BigInt(totalMembers) * circle.circleInfo.depositAmount;
   } else {
     roundsCompleted = circle.completedRounds;
@@ -60,7 +77,13 @@ const Overview = ({
         <Body bold className="text-xs shrink-0">
           <span className="font-normal">Stack status: </span>
           <span>
-            {roundsCompleted} out of {circle.totalRounds} rounds complete
+            {totalMembers === "-" ? (
+              "-"
+            ) : (
+              <>
+                {roundsCompleted} out of {totalMembers} rounds complete
+              </>
+            )}
           </span>
         </Body>
       </header>
@@ -68,8 +91,14 @@ const Overview = ({
         <Body className="flex flex-col justify-start md:items-start">
           <span className="text-surface-grey">Deposits made by</span>
           <span>
-            <span className="font-bold">{membersDeposited}</span> out of{" "}
-            <span className="font-bold">{totalMembers}</span> members
+            {totalMembers === "-" ? (
+              "-"
+            ) : (
+              <>
+                <span className="font-bold">{membersDeposited}</span> out of{" "}
+                <span className="font-bold">{totalMembers}</span> members
+              </>
+            )}
           </span>
         </Body>
         <Body className="flex flex-col justify-start md:items-center md:justify-center">
@@ -79,8 +108,9 @@ const Overview = ({
             <span className="font-bold mt-[0.2rem]">
               {formatBalance(+formatEther(poolBalance), 2)} of{" "}
               {formatBalance(
-                +formatEther(circle.circleInfo.depositAmount) * totalMembers,
-                3
+                +formatEther(circle.circleInfo.depositAmount) *
+                  (typeof totalMembers === "string" ? 0 : totalMembers),
+                2
               )}{" "}
               BREAD
             </span>

--- a/src/app/stacks/[id]/_components/stack-details.tsx
+++ b/src/app/stacks/[id]/_components/stack-details.tsx
@@ -113,6 +113,7 @@ const StackDetailsBreakdown = ({
   const capitalizedLabel = `${intervalLabel[0].toUpperCase()}${intervalLabel.slice(
     1
   )}`;
+  const _roundsLeft = status.status === "pending-start" ? "-" : roundsLeft;
 
   return (
     <div className="md:flex-1">
@@ -138,9 +139,9 @@ const StackDetailsBreakdown = ({
       <StackDetailsBreakdownRow label="Time left">
         <>
           <p className="text-h2 leading-6 tracking-[-2%] text-2xl">
-            {status.status === "finished" ? "0" : roundsLeft}
+            {status.status === "finished" ? "0" : _roundsLeft}
           </p>
-          <p>{capitalizedLabel}s</p>
+          {status.status !== "pending-start" && <p>{capitalizedLabel}s</p>}
         </>
       </StackDetailsBreakdownRow>
     </div>

--- a/src/app/stacks/join/_components/page-content.tsx
+++ b/src/app/stacks/join/_components/page-content.tsx
@@ -31,6 +31,9 @@ export default function PageContent() {
   const nonce = searchParams.get("nonce");
   const signature = searchParams.get("signature");
   const circleName = searchParams.get("name") || "-";
+  const members = Number(searchParams.get("members"));
+  const interval = searchParams.get("interval") || "";
+  const deposit = Number(searchParams.get("deposit"));
 
   const [redeeming, setRedeeming] = useState(false);
   const { sendSponsoredTransaction } = useSponsoredTx();
@@ -80,7 +83,10 @@ export default function PageContent() {
       let localCircles = JSON.parse(localStorage.getItem("circles") || "{}");
       localCircles = {
         ...localCircles,
-        [circleId]: { name: circleName },
+        [circleId]: {
+          name: circleName,
+          totalMembers: members,
+        },
       };
       localStorage.setItem("circles", JSON.stringify(localCircles));
 
@@ -130,14 +136,20 @@ export default function PageContent() {
                   <div className="">
                     <RowDetail label="Group name" body={circleName} />
                     <RowDetail label="Stacks group ID" body={circleId} />
-                    <RowDetail label="Duration" body="Duration" />
+                    <RowDetail
+                      label="Duration"
+                      body={`${members} ${interval}`}
+                    />
                     <RowDetail
                       label="Est. Deposit amount"
                       body={`${formatEther(
                         circleResult.data.depositAmount
                       )} BREAD`}
                     />
-                    <RowDetail label="Stack goal" body={`30 BREAD`} />
+                    <RowDetail
+                      label="Stack goal"
+                      body={`${members ** 2 * deposit} BREAD`}
+                    />
                   </div>
                 </AccordionContent>
               </AccordionItem>

--- a/src/components/_home/all-stacks.tsx
+++ b/src/components/_home/all-stacks.tsx
@@ -2,21 +2,15 @@
 
 import CardCarousel from "../card-carousel";
 import { useAllCircles } from "@/hooks/use-all-circles";
-import { Body, Heading2, useConnectedUser } from "@breadcoop/ui";
 import Loading from "@/app/loading";
+import HomeHeader from "./header";
 
 const HomeAllStacks = () => {
-  const { user } = useConnectedUser();
   const { data, isLoading } = useAllCircles();
 
   return (
     <section className="mt-6">
-      {(user.status === "CONNECTED" || user.status === "NOT_CONNECTED") && (
-        <div className="flex flex-col gap-6 mb-6 md:mb-0">
-          <Heading2 className="m-0 p-0 text-2xl leading-6">All Stacks</Heading2>
-          <Body>Peek into all active Stack groups.</Body>
-        </div>
-      )}
+      <HomeHeader type="all" />
       <div className="mt-6">
         {isLoading ? <Loading /> : <CardCarousel circles={data} />}
       </div>

--- a/src/components/_home/header.tsx
+++ b/src/components/_home/header.tsx
@@ -5,28 +5,28 @@ import LocalLiftedButton from "../lifted-button";
 import Link from "next/link";
 import { PlusIcon } from "@phosphor-icons/react";
 
-const HomeHeader = () => {
+const HomeHeader = ({ type }: { type: "all" | "persona" }) => {
   const { user } = useConnectedUser();
-  const isConnected =
-    user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN";
 
   return (
     <header className="mb-6 md:flex md:items-center md:justify-between">
       <div className="flex flex-col gap-6 mb-6 md:mb-0">
         <Heading2 className="m-0 p-0 text-2xl leading-6">
-          {isConnected ? "Your Stacks" : "All Stacks"}
+          {type === "persona" ? "Your Stacks" : "All Stacks"}
         </Heading2>
         <Body>
-          {isConnected
+          {type === "persona"
             ? "Peek into your Stacks dashboard."
             : "Peek into all active Stack groups."}
         </Body>
       </div>
-      <Link href="/new" className="lifted-button-container md:w-auto">
-        <LocalLiftedButton leftIcon={<PlusIcon />}>
-          Create new Stack
-        </LocalLiftedButton>
-      </Link>
+      {(type === "persona" || user.status !== "CONNECTED") && (
+        <Link href="/new" className="lifted-button-container md:w-auto">
+          <LocalLiftedButton leftIcon={<PlusIcon />}>
+            Create new Stack
+          </LocalLiftedButton>
+        </Link>
+      )}
     </header>
   );
 };

--- a/src/components/_home/home.tsx
+++ b/src/components/_home/home.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import HomeAllStacks from "./all-stacks";
-import HomeHeader from "./header";
 // import HomeLoggedInDetails from "./logged-in-details";
 
 export const HomeContent = () => {
   return (
     <div>
-      <HomeHeader />
       {/* <HomeLoggedInDetails /> */}
       <HomeAllStacks />
     </div>

--- a/src/components/_home/logged-in-details.tsx
+++ b/src/components/_home/logged-in-details.tsx
@@ -1,3 +1,4 @@
+import HomeHeader from "./header";
 import HomeTab from "./tab";
 import HomeUserStacks from "./user-stacks";
 import { useConnectedUser } from "@breadcoop/ui";
@@ -10,6 +11,7 @@ const HomeLoggedInDetails = () => {
 
   return (
     <>
+      <HomeHeader type="persona" />
       <HomeTab />
       <HomeUserStacks address={user.address} />
     </>

--- a/src/components/deposit-button.tsx
+++ b/src/components/deposit-button.tsx
@@ -7,8 +7,8 @@ import {
 } from "@breadcoop/ui";
 import { useModal } from "./modal/context";
 import { localButtonClassNames } from "./lifted-button";
-import { useReadContract, useSimulateContract, useWriteContract } from "wagmi";
-import { Address, erc20Abi } from "viem";
+import { useReadContract } from "wagmi";
+import { Address, encodeFunctionData, erc20Abi } from "viem";
 import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
 import { useMemo, useState } from "react";
 import { waitForTransactionReceipt } from "@wagmi/core";
@@ -18,6 +18,7 @@ import { getDefaultChainId } from "@/utils/chain";
 import { useQueryClient } from "@tanstack/react-query";
 import Loading from "@/app/loading";
 import { MAX_UINT256 } from "@/utils/solidity";
+import { useSponsoredTx } from "@/hooks/use-sponsored-tx";
 
 interface DepositButtonProps extends Omit<LiftedButtonProps, "children"> {
   label?: string;
@@ -36,6 +37,7 @@ const DepositButton = ({
 }: DepositButtonProps) => {
   const [depositing, setDepositing] = useState(false);
   const queryClient = useQueryClient();
+  const { sendSponsoredTransaction } = useSponsoredTx();
   const { user } = useConnectedUser();
   const userAddress = user.status === "CONNECTED" ? user.address : undefined;
   const modal = useModal();
@@ -59,17 +61,6 @@ const DepositButton = ({
     return allowance < amount;
   }, [allowance, amount, userAddress]);
 
-  const { data: approveConfig } = useSimulateContract({
-    address: tokenAddress,
-    abi: erc20Abi,
-    functionName: "approve",
-    args: [SAVING_CIRCLES_CONTRACT_ADDRESS, MAX_UINT256],
-    query: { enabled: needsApproval && !!userAddress },
-  });
-
-  const { writeContractAsync: writeApprove } = useWriteContract();
-  const { writeContractAsync: writeDeposit } = useWriteContract();
-
   const deposit = async () => {
     if (depositing) return;
 
@@ -78,24 +69,31 @@ const DepositButton = ({
 
     try {
       if (needsApproval) {
-        const approveHash = await writeApprove({
-          ...approveConfig!.request,
+        const approveData = encodeFunctionData({
+          abi: erc20Abi,
+          functionName: "approve",
+          args: [SAVING_CIRCLES_CONTRACT_ADDRESS, MAX_UINT256],
         });
 
-        console.log({ approveHash });
+        const { hash: approveHash } = await sendSponsoredTransaction({
+          to: tokenAddress,
+          data: approveData,
+        });
 
-        const approveReceipt = await waitForTransactionReceipt(wagmiConfig, {
+        await waitForTransactionReceipt(wagmiConfig, {
           hash: approveHash,
         });
-
-        console.log({ approveReceipt });
       }
 
-      const depositHash = await writeDeposit({
-        address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+      const depositData = encodeFunctionData({
         abi: savingCirclesAbi,
         functionName: "deposit",
         args: [circleId, amount],
+      });
+
+      const { hash: depositHash } = await sendSponsoredTransaction({
+        to: SAVING_CIRCLES_CONTRACT_ADDRESS,
+        data: depositData,
       });
 
       await waitForTransactionReceipt(wagmiConfig, { hash: depositHash });

--- a/src/components/modal/modals/stack-result.tsx
+++ b/src/components/modal/modals/stack-result.tsx
@@ -41,7 +41,10 @@ function buildInviteUrl(
   circleId: string,
   nonce: bigint,
   signature: string,
-  name: string
+  name: string,
+  members: number,
+  interval: string,
+  deposit: string
 ): string {
   const url = new URL(baseUrl);
   url.searchParams.set("contract", SAVING_CIRCLES_CONTRACT_ADDRESS);
@@ -49,6 +52,9 @@ function buildInviteUrl(
   url.searchParams.set("nonce", nonce.toString());
   url.searchParams.set("signature", signature);
   url.searchParams.set("name", name);
+  url.searchParams.set("members", String(members));
+  url.searchParams.set("interval", interval);
+  url.searchParams.set("deposit", deposit);
 
   return url.toString();
 }
@@ -146,7 +152,10 @@ export const StackSuccessResultModal = ({
           modalState.circle.id,
           nonce,
           signature,
-          modalState.circle.name
+          modalState.circle.name,
+          modalState.circle.members,
+          modalState.circle.duration.split(" ")[1],
+          formatBalance(modalState.circle.deposit, 2)
         );
 
         signedInvites.push({ nonce, signature, url, used: false });

--- a/src/components/stack.tsx
+++ b/src/components/stack.tsx
@@ -1,35 +1,16 @@
-import {
-  Body,
-  Heading3,
-  Chip,
-  formatBalance,
-  // LiftedButton
-} from "@breadcoop/ui";
+import { Body, Heading3, Chip, formatBalance } from "@breadcoop/ui";
 import { UsersIcon } from "./icons/users";
 import { CoinIcon, CoinsIcon } from "./icons/coin";
 import { CalendarIcon } from "./icons/calendar";
 import LocalLiftedButton from "./lifted-button";
 import Link from "next/link";
-import {
-  // HandWithdrawIcon,
-  QuestionIcon,
-} from "@phosphor-icons/react/ssr";
-// import { useModal } from "./modal/context";
+import { QuestionIcon } from "@phosphor-icons/react/ssr";
 import ClaimButton from "./claim-button";
 import { ICircleList, LocalStorageCircle } from "@/interfaces/circle";
 import { formatEther } from "viem";
 import DepositButton from "./deposit-button";
 import { HandWithdrawIcon } from "@phosphor-icons/react";
 import { parseCircleIntervalToDate } from "@/utils/stacks";
-
-// const headerStatuses: ICircleList["status"][] = [
-//   "payment_due",
-//   "claimable",
-//   "pending-start",
-//   "in-progress",
-//   "finished",
-//   "expired",
-// ];
 
 const Stack = ({
   stack,
@@ -38,7 +19,6 @@ const Stack = ({
   stack: ICircleList;
   stackNames: Record<string, LocalStorageCircle>;
 }) => {
-  // const { setModal } = useModal();
   const depositAmount = formatEther(stack.depositAmount);
   const totalGoal =
     Number(depositAmount) * stack.totalMember * stack.totalMember;

--- a/src/interfaces/circle.ts
+++ b/src/interfaces/circle.ts
@@ -43,7 +43,8 @@ export type ICircleList = ICircleBaseList &
 
 export interface LocalStorageCircle {
   name: string;
-  invite_links: string[];
+  invite_links?: string[];
+  totalMembers: number;
 }
 
 export type LocalStorageCircles = Record<string, LocalStorageCircle>;


### PR DESCRIPTION
Closes: #30, Closes #27
## Summary
This PR combines the original local tx/deploy stability updates with additional fixes for deterministic local deploy behavior and round UI/action semantics.

## Includes
- Make `saving-circles` submodule branch configurable (default now: `feat/member-withdrawable-view`).
- Enable optimizer flags in deploy with configurable runs.
- Use unsponsored tx flow in local while keeping sponsorship in production.
- Route deposit `approve` + `deposit` through the same Privy tx path to avoid signer mismatch.

## Additional updates in this PR
- Prevent `make deploy` from unexpectedly changing contract versions:
  - remove implicit `forge install` from deploy.
  - add explicit `install-contract-deps` target.
- Update stack timing/action UI:
  - rename label to `Days left until current round ends`.
  - show deposit action based on real current-round eligibility (`canDeposit`), enabling coexistence with withdraw availability when both are valid.
