### PR TITLE
fix: use member claimability for claim UI

### DIFF
--- a/src/app/stacks/[id]/_components/overview.tsx
+++ b/src/app/stacks/[id]/_components/overview.tsx
@@ -48,11 +48,18 @@ const Overview = ({
   const now = useBlockTimestamp();
   const { setModal } = useModal();
   const connectedUser = useConnectedUser();
+  const nowSeconds = BigInt(Math.floor(now / 1000));
   const formattedCircleStatus = getUserCircleStatus(
     circle,
     member,
     { includeClaimable: true },
-    BigInt(Math.floor(now / 1000))
+    nowSeconds
+  );
+  const depositCircleStatus = getUserCircleStatus(
+    circle,
+    member,
+    { includeDeposited: true },
+    nowSeconds
   );
   const { data: stackMetadata } = useStackSupabase(
     circle.circleId.toString(),
@@ -87,15 +94,24 @@ const Overview = ({
     },
   });
 
-  const pendingInvites = nonceChecks.filter((_, index) => {
-    if (!nonceResults || nonceResults.length <= index) return false;
-    const result = nonceResults[index];
-    if (result.status !== "success") return false;
-    return result.result === false;
-  }).length;
-
   const expectedMembers = stackMetadata?.expected_members ?? 0;
-  const invitesComplete = pendingInvites === 0 && expectedMembers > 0;
+  const acceptedMembers = Number(circle.totalRounds);
+  const hasEnoughMembersToStart = acceptedMembers >= 2;
+  const hasInviteMetadata = expectedMembers > 0 || nonceChecks.length > 0;
+  const inviteStatusReady =
+    nonceChecks.length === 0 || nonceResults?.length === nonceChecks.length;
+
+  const pendingInvites = inviteStatusReady
+    ? nonceChecks.filter((_, index) => {
+        const result = nonceResults?.[index];
+        if (result?.status !== "success") return true;
+        return result.result === false;
+      }).length
+    : nonceChecks.length;
+
+  const invitesComplete = hasInviteMetadata
+    ? hasEnoughMembersToStart && inviteStatusReady && pendingInvites === 0
+    : hasEnoughMembersToStart;
 
   const totalMembers =
     formattedCircleStatus.status === "pending-start"
@@ -229,7 +245,7 @@ const Overview = ({
               </LiftedButton>
             )}
           </>
-        ) : formattedCircleStatus.status === "payment_due" ? (
+        ) : depositCircleStatus.status === "payment_due" ? (
           <>
             {connectedUser.user.status === "CONNECTED" ? (
               <DepositButton

--- a/src/hooks/use-user-circles-list.ts
+++ b/src/hooks/use-user-circles-list.ts
@@ -33,7 +33,7 @@ export function useUserCirclesList(address: Address) {
         { includeClaimable: true },
         now
       ).status;
-      const canWithdraw = c.canWithdraw && c.isCurrentWithdrawer;
+      const canWithdraw = c.canWithdraw;
 
       return {
         ...c.circleInfo,

--- a/src/lib/abis/saving-circles-viewers.ts
+++ b/src/lib/abis/saving-circles-viewers.ts
@@ -279,6 +279,11 @@ export const savingCirclesViewerAbi = [
                 type: "uint256",
                 internalType: "uint256",
               },
+              {
+                name: "currentWithdrawer",
+                type: "address",
+                internalType: "address",
+              },
             ],
           },
           {
@@ -453,6 +458,11 @@ export const savingCirclesViewerAbi = [
             type: "uint256",
             internalType: "uint256",
           },
+          {
+            name: "currentWithdrawer",
+            type: "address",
+            internalType: "address",
+          },
         ],
       },
     ],
@@ -595,6 +605,11 @@ export const savingCirclesViewerAbi = [
             name: "totalRounds",
             type: "uint256",
             internalType: "uint256",
+          },
+          {
+            name: "currentWithdrawer",
+            type: "address",
+            internalType: "address",
           },
         ],
       },

--- a/src/lib/get-user-circle-status.ts
+++ b/src/lib/get-user-circle-status.ts
@@ -28,7 +28,6 @@ export const getUserCircleStatus = (
   now = BigInt(Math.floor(Date.now() / 1000))
 ): IFormattedUserCircleStatusResult => {
   const isOwner = circle.isOwner;
-  const isCurrentWithdrawer = circle.isCurrentWithdrawer;
   // const now = BigInt(Math.floor(Date.now() / 1000));
   const hasDepositedThisRound =
     circle.userBalance >= circle.circleInfo.depositAmount;
@@ -106,29 +105,28 @@ export const getUserCircleStatus = (
     };
   }
 
-  // if (config.includeClaimable && canWithdraw) {
+  if (config.includeClaimable && circle.canWithdraw) {
+    return {
+      status: "claimable",
+      statusLabel: "Claimable",
+      variant: "success",
+      title: "It's your turn to claim",
+      desc: "All deposits for your claim round are complete. Withdraw the full pot now.",
+    };
+  }
+
   if (
     config.includeClaimable &&
     circle.totalPoolBalance ===
       circle.circleInfo.depositAmount * circle.totalRounds
   ) {
-    if (isCurrentWithdrawer) {
-      return {
-        status: "claimable",
-        statusLabel: "Claimable",
-        variant: "success",
-        title: "It's your turn to claim",
-        desc: "All deposits for this round are complete. Withdraw the full pot now.",
-      };
-    } else {
-      return {
-        status: "deposit-completed",
-        statusLabel: "Deposits Completed",
-        variant: "success",
-        title: "Round deposits complete",
-        desc: "Waiting for the current withdrawer to claim this round's payout.",
-      };
-    }
+    return {
+      status: "deposit-completed",
+      statusLabel: "Deposits Completed",
+      variant: "success",
+      title: "Round deposits complete",
+      desc: "Waiting for the eligible member to claim this round's payout.",
+    };
   }
 
   if (config.includeDeposited && hasDepositedThisRound) {


### PR DESCRIPTION
Closes https://github.com/BreadchainCoop/saving-circles/issues/156

## Summary

Fixes the claim UI so claim availability is based on the connected member’s individual `canWithdraw` status instead of requiring them to be the current round withdrawer.

## Changes

- Shows the claimable state when the viewer contract reports `circle.canWithdraw`.
- Removes the extra `isCurrentWithdrawer` gate from the user circles list.
- Updates waiting copy to refer to an eligible member instead of the current withdrawer.

  ## Why

Claims are not required to happen in strict round order. If an earlier eligible member has not claimed, later eligible members should still be able to claim once their own claim round has passed.