### PR TITLE
Normalize stack states and improve dashboard stack actions

### DIFF
--- a/src/app/stacks/[id]/_components/days-left.tsx
+++ b/src/app/stacks/[id]/_components/days-left.tsx
@@ -2,8 +2,13 @@
 
 import Countdown from "@/components/countdown";
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
+import { ICircleRoundState } from "@/interfaces/circle";
 import { Body } from "@breadcoop/ui";
-import { CalendarStarIcon } from "@phosphor-icons/react";
+import {
+  CalendarCheckIcon,
+  CalendarDotIcon,
+  CalendarStarIcon,
+} from "@phosphor-icons/react";
 
 const DaysLeft = ({
   depositWindowEnd,
@@ -11,18 +16,28 @@ const DaysLeft = ({
   currentIndex,
   depositInterval,
   isActive,
+  circleEnd,
+  roundState,
 }: {
   depositWindowEnd: bigint | undefined;
   effectiveCircleStartTime: bigint | undefined;
   currentIndex: bigint | undefined;
   depositInterval: bigint | undefined;
   isActive?: boolean;
+  circleEnd?: bigint;
+  roundState?: ICircleRoundState;
 }) => {
   const blockTimestamp = useBlockTimestamp();
   let daysLeft = "-";
   let progressPercent = 0;
+  const isCompleted = roundState === "finished";
+  const isPendingStart = roundState === "not-started";
+  const isStopped = roundState === "failed";
 
-  if (
+  if (isCompleted) {
+    progressPercent = 100;
+  } else if (
+    !isStopped &&
     depositWindowEnd &&
     isActive &&
     effectiveCircleStartTime &&
@@ -52,26 +67,69 @@ const DaysLeft = ({
     }
   }
 
+  const completedDate =
+    circleEnd && Number(circleEnd) > 0
+      ? new Intl.DateTimeFormat("en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        }).format(new Date(Number(circleEnd) * 1000))
+      : null;
+
   return (
     <div>
       <div>
         <div className="flex items-center justify-start gap-0.5">
-          <CalendarStarIcon size={24} className="fill-blue-2" />
-          <Body>Days left until current round ends</Body>
+          {isCompleted ? (
+            <CalendarCheckIcon size={24} className="fill-system-green" />
+          ) : isPendingStart || isStopped ? (
+            <CalendarDotIcon size={24} className="fill-surface-grey" />
+          ) : (
+            <CalendarStarIcon size={24} className="fill-blue-2" />
+          )}
+          <Body
+            className={
+              isPendingStart || isStopped ? "text-surface-grey" : undefined
+            }
+          >
+            {isCompleted
+              ? "Circle completed"
+              : isPendingStart
+                ? "Waiting for circle to start"
+                : isStopped
+                  ? "Stack failed"
+                  : roundState === "deposits-complete"
+                    ? "Deposits complete"
+                    : "Days left until current round ends"}
+          </Body>
         </div>
-        <p className="text-h2 text-2xl leading-6 mt-2">{daysLeft}</p>
+        {!isCompleted && !isPendingStart && !isStopped && (
+          <p className="text-h2 text-2xl leading-6 mt-2">{daysLeft}</p>
+        )}
       </div>
       <div className="w-full h-4 bg-paper-2 mt-4 mb-2 p-0.75">
         <div
-          className="h-full bg-primary-blue"
+          className={`h-full ${
+            isCompleted
+              ? "bg-system-green"
+              : isPendingStart || isStopped
+                ? "bg-surface-grey"
+                : "bg-primary-blue"
+          }`}
           style={{ width: `${progressPercent}%` }}
         />
       </div>
-      {Boolean(Number(effectiveCircleStartTime)) && isActive && (
-        <Countdown
-          targetSeconds={Number(depositWindowEnd)}
-          // key={depositWindowEnd}
-        />
+      {isCompleted ? (
+        <Body className="text-system-green">
+          {completedDate ? `Completed on ${completedDate}` : "Circle completed"}
+        </Body>
+      ) : isPendingStart || isStopped ? null : (
+        isActive && (
+          <Countdown
+            targetSeconds={Number(depositWindowEnd)}
+            // key={depositWindowEnd}
+          />
+        )
       )}
     </div>
   );

--- a/src/app/stacks/[id]/_components/overview.tsx
+++ b/src/app/stacks/[id]/_components/overview.tsx
@@ -33,6 +33,14 @@ const failedStatuses: ICircleStatus[] = [
   "finished",
 ];
 
+const roundStateClassNames = {
+  "not-started": "text-primary-blue",
+  "in-progress": "text-system-warning",
+  "deposits-complete": "text-system-green",
+  finished: "text-system-green",
+  failed: "text-system-red",
+} as const;
+
 const Overview = ({
   circle,
   member,
@@ -117,6 +125,7 @@ const Overview = ({
     formattedCircleStatus.status === "pending-start"
       ? expectedMembers || "-"
       : Number(circle.totalRounds);
+  const roundState = formattedCircleStatus.roundState;
 
   let roundsCompleted = BigInt(0);
   let membersDeposited: bigint | number = BigInt(0);
@@ -142,7 +151,7 @@ const Overview = ({
           <span className="font-normal">Stack status: </span>
           <span>
             {failedStatuses.includes(formattedCircleStatus.status) ? (
-              <>{formattedCircleStatus.status}</>
+              <>{formattedCircleStatus.roundStateLabel}</>
             ) : totalMembers === "-" ? (
               "-"
             ) : (
@@ -194,20 +203,10 @@ const Overview = ({
           <span
             className={cn(
               "font-bold",
-              formattedCircleStatus.status === "pending-start" &&
-                "text-primary-blue",
-              ["payment_due", "in-progress"].includes(
-                formattedCircleStatus.status
-              ) && "text-system-warning",
-              formattedCircleStatus.status === "failed" && "text-system-red",
-              ["finished", "claimable", "deposit-completed"].includes(
-                formattedCircleStatus.status
-              ) && "text-system-green"
+              roundStateClassNames[formattedCircleStatus.roundState]
             )}
           >
-            {formattedCircleStatus.status === "payment_due"
-              ? "In Progress"
-              : formattedCircleStatus.statusLabel}
+            {formattedCircleStatus.roundStateLabel}
           </span>
         </Body>
       </div>
@@ -217,10 +216,9 @@ const Overview = ({
         effectiveCircleStartTime={circle.circleInfo.effectiveCircleStartTime}
         currentIndex={circle.circleInfo.currentIndex}
         depositInterval={circle.circleInfo.depositInterval}
-        isActive={
-          status.isActive &&
-          !failedStatuses.includes(formattedCircleStatus.status)
-        }
+        isActive={status.isActive}
+        circleEnd={circle.circleInfo.circleEnd}
+        roundState={roundState}
       />
       <div className="mt-4">
         {formattedCircleStatus.status === "pending-start" ? (
@@ -263,13 +261,6 @@ const Overview = ({
               <LoginButton app="stacks" status={connectedUser.user.status} />
             )}
           </>
-        ) : formattedCircleStatus.status === "deposit-completed" ? (
-          <Body
-            bold
-            className="py-4 px-8 text-paper-main bg-surface-grey text-center opacity-50"
-          >
-            Awaiting current withdrawer to claim
-          </Body>
         ) : formattedCircleStatus.status === "failed" &&
           circle.isDecommissionable &&
           !circle.isDecommissioned &&

--- a/src/app/stacks/[id]/_components/stack-details.tsx
+++ b/src/app/stacks/[id]/_components/stack-details.tsx
@@ -1,7 +1,7 @@
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
 import { useGetCircleCreated } from "@/hooks/use-get-cricle-created";
 import { useUserCircleData } from "@/hooks/use-user-circle-data";
-import { ICircleStatus, MemberCircleInfo } from "@/interfaces/circle";
+import { MemberCircleInfo } from "@/interfaces/circle";
 import {
   getUserCircleStatus,
   IFormattedUserCircleStatusResult,
@@ -22,13 +22,6 @@ import {
 import { CalendarDotsIcon } from "@phosphor-icons/react/ssr";
 import { ReactNode } from "react";
 import { formatEther, zeroAddress } from "viem";
-
-const failedStatuses: ICircleStatus[] = [
-  "decommissioned",
-  "expired",
-  "failed",
-  "finished",
-];
 
 const StackDetailsTotal = ({
   intervalLabel,
@@ -127,6 +120,8 @@ const StackDetailsBreakdown = ({
   let _roundsLeft = "-";
 
   const parsedInterval = splitIntervalId(intervalId);
+  const hasNoTimeLeft =
+    status.roundState === "failed" || status.roundState === "finished";
 
   if (status.status !== "pending-start") {
     _roundsLeft = `${+roundsLeft * parsedInterval[0]}`;
@@ -157,9 +152,11 @@ const StackDetailsBreakdown = ({
         <>
           <p className="text-h2 leading-6 tracking-[-2%] text-2xl">
             {/* {status.status === "finished" ? "0" : _roundsLeft} */}
-            {failedStatuses.includes(status.status) ? "0" : _roundsLeft}
+            {hasNoTimeLeft ? "0" : _roundsLeft}
           </p>
-          {status.status !== "pending-start" && <p>{parsedInterval[1]}</p>}
+          {status.status !== "pending-start" && !hasNoTimeLeft && (
+            <p>{parsedInterval[1]}</p>
+          )}
         </>
       </StackDetailsBreakdownRow>
     </div>
@@ -199,7 +196,9 @@ const StackDetails = ({
     BigInt(Math.floor(blockTimestamp / 1000))
   );
   const roundsLeft =
-    circleStatus.status === "finished" ? 0 : members - circle.currentIndex;
+    circleStatus.roundState === "finished"
+      ? 0
+      : Math.max(0, Number(members - circle.currentIndex));
 
   return (
     <section className="bg-paper-0 flex flex-col gap-6 p-4">

--- a/src/components/_home/all-stacks.tsx
+++ b/src/components/_home/all-stacks.tsx
@@ -6,11 +6,17 @@ import Loading from "@/app/loading";
 import HomeHeader from "./header";
 import { usePrivy } from "@privy-io/react-auth";
 import { useUserStacksMetadata } from "@/hooks/use-user-stacks-metadata";
+import { Body } from "@breadcoop/ui";
+import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { useState } from "react";
 
 const HomeAllStacks = () => {
-  const { data, isLoading } = useAllCircles();
+  const [page, setPage] = useState(0);
+  const { data, isLoading, hasMore, total } = useAllCircles(page);
   const { user } = usePrivy();
   const { stacksMap } = useUserStacksMetadata(user?.id);
+  const canGoBack = page > 0 && !isLoading;
+  const canGoForward = hasMore && !isLoading;
 
   return (
     <section className="mt-6">
@@ -19,7 +25,34 @@ const HomeAllStacks = () => {
         {isLoading ? (
           <Loading />
         ) : (
-          <CardCarousel circles={data} stacksMap={stacksMap} />
+          <>
+            <CardCarousel circles={data} stacksMap={stacksMap} />
+            {total > 9 && (
+              <div className="flex items-center justify-center gap-4 py-2">
+                <button
+                  onClick={() => setPage((current) => Math.max(0, current - 1))}
+                  disabled={!canGoBack}
+                  className="transition-colors text-primary-blue disabled:opacity-20"
+                  aria-label="Previous stacks page"
+                  type="button"
+                >
+                  <CaretLeftIcon className="w-6 h-6" />
+                </button>
+
+                <Body bold>Page {page + 1}</Body>
+
+                <button
+                  onClick={() => setPage((current) => current + 1)}
+                  disabled={!canGoForward}
+                  className="transition-colors text-primary-blue disabled:opacity-20"
+                  aria-label="Next stacks page"
+                  type="button"
+                >
+                  <CaretRightIcon className="w-6 h-6" />
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </section>

--- a/src/components/_home/home.tsx
+++ b/src/components/_home/home.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import HomeAllStacks from "./all-stacks";
-// import HomeLoggedInDetails from "./logged-in-details";
+import HomeLoggedInDetails from "./logged-in-details";
 
 export const HomeContent = () => {
   return (
     <div>
-      {/* <HomeLoggedInDetails /> */}
+      <HomeLoggedInDetails />
       <HomeAllStacks />
     </div>
   );

--- a/src/components/_home/user-stacks.tsx
+++ b/src/components/_home/user-stacks.tsx
@@ -12,6 +12,17 @@ import { useUserStacksMetadata } from "@/hooks/use-user-stacks-metadata";
 
 type Tab = "due" | "claim" | "past" | "all";
 
+const pastRoundStates = ["finished", "failed"];
+
+const hasFailedClaim = (circle: {
+  status?: string;
+  isDecommissionable?: boolean;
+  userBalance?: bigint;
+}) =>
+  circle.status === "failed" &&
+  circle.isDecommissionable &&
+  Boolean(circle.userBalance && circle.userBalance > BigInt(0));
+
 const HomeUserStacks = ({ address }: { address: Address }) => {
   const userCirclesList = useUserCirclesList(address);
   const { user } = usePrivy();
@@ -24,21 +35,17 @@ const HomeUserStacks = ({ address }: { address: Address }) => {
     circles = [...circles].filter((c) => {
       if (tab === "due") return c.status === "payment_due";
 
-      if (tab === "claim") return c.status === "claimable";
+      if (tab === "claim") return c.status === "claimable" || hasFailedClaim(c);
 
       if (tab === "past") {
-        if (!c.status) return false;
+        if (!c.roundState) return false;
 
-        return ["decommissioned", "finished", "failed", "expired"].includes(
-          c.status
-        );
+        return pastRoundStates.includes(c.roundState);
       }
 
       return true;
     });
   }
-
-  console.log("_ CIRCLES __", circles);
 
   return (
     <div>

--- a/src/components/lifted-button.tsx
+++ b/src/components/lifted-button.tsx
@@ -8,7 +8,7 @@ export const localButtonClassNames = {
   secondary: "bg-[#B9D5FF] text-primary-blue",
   stroke: "bg-paper-main text-system-green",
   positive: "",
-  destructive: "",
+  destructive: "bg-red-0 text-system-red",
 };
 
 const LocalLiftedButton = ({

--- a/src/components/modal/modals/stack-failed.tsx
+++ b/src/components/modal/modals/stack-failed.tsx
@@ -47,6 +47,7 @@ const StackFailed = ({ modalState }: { modalState: StackFailedModalState }) => {
         args: [modalState.id],
       });
       queryClient.invalidateQueries({ queryKey: ["readContract"] });
+      queryClient.invalidateQueries({ queryKey: ["readContracts"] });
 
       setFeedback({
         type: "success",

--- a/src/components/stack.tsx
+++ b/src/components/stack.tsx
@@ -9,9 +9,10 @@ import ClaimButton from "./claim-button";
 import { ICircleList } from "@/interfaces/circle";
 import { formatEther } from "viem";
 import DepositButton from "./deposit-button";
-import { HandWithdrawIcon } from "@phosphor-icons/react";
+import { CheckCircleIcon, HandWithdrawIcon } from "@phosphor-icons/react";
 import { parseCircleIntervalToDate } from "@/utils/stacks";
 import { Database } from "@/lib/supabase";
+import { useModal } from "./modal/context";
 
 type StackMetadata = Database["public"]["Tables"]["stacks_metadata"]["Row"];
 
@@ -22,6 +23,7 @@ const Stack = ({
   stack: ICircleList;
   stacksMap: Record<string, StackMetadata>;
 }) => {
+  const { setModal } = useModal();
   const stackMeta = stacksMap[String(stack.id)];
   const depositAmount = formatEther(stack.depositAmount);
   const totalGoal =
@@ -33,7 +35,24 @@ const Stack = ({
       Number(depositAmount) *
       Number(stack.totalMember) +
     Number(formatEther(stack.totalPoolBalance || BigInt(0)));
-  const percentageDone = (totalDeposited / totalGoal) * 100;
+  const percentageDone = totalGoal > 0 ? (totalDeposited / totalGoal) * 100 : 0;
+  const roundState = stack.roundState;
+  const roundStateLabel =
+    roundState === "not-started"
+      ? "Not started"
+      : roundState === "deposits-complete"
+        ? "Deposits complete"
+        : roundState === "finished"
+          ? "Finished"
+          : roundState === "failed"
+            ? "Failed"
+            : null;
+  const hasInactiveProgress =
+    roundState === "not-started" || roundState === "failed";
+  const hasFailedClaim =
+    stack.status === "failed" &&
+    stack.isDecommissionable &&
+    Boolean(stack.userBalance && stack.userBalance > BigInt(0));
 
   const items = [
     {
@@ -60,12 +79,6 @@ const Stack = ({
     },
   ];
 
-  const statusMode = !stack.status
-    ? undefined
-    : stack.status === "expired" || stack.status === "finished"
-      ? ""
-      : stack.status;
-
   return (
     <li className="border border-paper-1 p-6 flex flex-col gap-6 bg-paper-0 shadow-[0px_4px_12px_0px_#1B201A26] xl:max-w-94">
       <div className="flex flex-col gap-2">
@@ -76,17 +89,23 @@ const Stack = ({
           <Body bold className="text-surface-grey">
             ID: {stack.id}
           </Body>
-          {statusMode && (
-            <Chip
-              className={`font-bold border-current! ${
-                stack.status === "payment_due"
-                  ? "text-system-warning"
-                  : "text-system-green"
-              }`}
-            >
-              {stack.status === "payment_due" ? "Payment due" : "Member"}
-            </Chip>
-          )}
+          <div className="flex items-center justify-end gap-2">
+            {stack.isMember && (
+              <Chip className="border-system-green text-system-green bg-paper-main max-w-max hover:border-current">
+                Member
+              </Chip>
+            )}
+            {stack.status === "payment_due" && (
+              <Chip className="font-bold border-current! text-system-warning">
+                Payment due
+              </Chip>
+            )}
+            {roundState === "failed" && (
+              <Chip className="font-bold border-current! text-system-red">
+                Failed
+              </Chip>
+            )}
+          </div>
         </div>
       </div>
       <div className="flex items-center justify-between gap-6">
@@ -95,14 +114,32 @@ const Stack = ({
             <Body bold className="text-xs sm:text-base">
               Stack progress
             </Body>
-            <Body bold className="text-xs sm:text-base">
-              {Math.round(percentageDone * 100) / 100}%
-            </Body>
+            {roundStateLabel ? (
+              <Body className="text-xs sm:text-sm text-surface-grey">
+                {roundStateLabel}
+              </Body>
+            ) : (
+              <Body bold className="text-xs sm:text-base">
+                {Math.round(percentageDone * 100) / 100}%
+              </Body>
+            )}
           </div>
-          <div className="w-full h-3.5 p-0.75 bg-paper-main">
+          <div
+            className={`w-full h-3.5 p-0.75 ${
+              hasInactiveProgress ? "bg-paper-2" : "bg-paper-main"
+            }`}
+          >
             <div
-              className="h-full bg-primary-blue"
-              style={{ width: `${percentageDone}%` }}
+              className={`h-full ${
+                roundState === "finished"
+                  ? "bg-system-green"
+                  : hasInactiveProgress
+                    ? "bg-surface-grey"
+                    : "bg-primary-blue"
+              }`}
+              style={{
+                width: `${hasInactiveProgress ? 0 : percentageDone}%`,
+              }}
             />
           </div>
         </div>
@@ -153,13 +190,30 @@ const Stack = ({
             leftIcon={<HandWithdrawIcon />}
             amount={stack.depositAmount}
           />
-        ) : statusMode === "" ? (
+        ) : roundState === "finished" ? (
+          <Body
+            bold
+            className="flex items-center justify-center gap-2 bg-system-green text-paper-main py-4 px-8"
+          >
+            <CheckCircleIcon size={20} />
+            Completed
+          </Body>
+        ) : hasFailedClaim ? (
+          <LocalLiftedButton
+            className="font-bold"
+            preset="destructive"
+            width="full"
+            onClick={() => setModal({ type: "STACK_FAILED", id: stack.id })}
+          >
+            Claim last deposits
+          </LocalLiftedButton>
+        ) : roundState === "failed" ? (
           <Body
             bold
             className="flex items-center justify-center gap-2 bg-surface-grey text-surface-ink opacity-50 py-4 px-8"
           >
             <HandWithdrawIcon />
-            Retired
+            Failed
           </Body>
         ) : null}
         <Link

--- a/src/hooks/use-all-circles.ts
+++ b/src/hooks/use-all-circles.ts
@@ -1,15 +1,25 @@
 import { useReadContracts } from "wagmi";
-import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "../lib/constants";
-import { savingCirclesAbi } from "../lib/abis/saving-circles";
+import { SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS } from "../lib/constants";
+import { savingCirclesViewerAbi } from "../lib/abis/saving-circles-viewers";
 import { ICircleList } from "@/interfaces/circle";
 import { useTotalCircles } from "./use-total-circles";
-import { Address } from "viem";
+import { zeroAddress } from "viem";
 import { getDefaultChainId } from "@/utils/chain";
+import { useBlockTimestamp } from "./use-block-timestamp";
+import { getUserCircleStatus } from "@/lib/get-user-circle-status";
+import { useConnectedUser } from "@breadcoop/ui";
 
-const PAGE_SIZE = 40;
+const PAGE_SIZE = 9;
+type UserCircleData = Parameters<typeof getUserCircleStatus>[0];
 
 export function useAllCircles(page: number = 0) {
   const skip = page * PAGE_SIZE;
+  const blockTimestamp = useBlockTimestamp();
+  const { user } = useConnectedUser();
+  const memberAddress =
+    user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN"
+      ? user.address
+      : zeroAddress;
 
   const { total: totalCircles, isLoading: loadingTotal } = useTotalCircles();
 
@@ -21,22 +31,13 @@ export function useAllCircles(page: number = 0) {
   );
 
   const { data: rawResults, isLoading: loadingCircles } = useReadContracts({
-    contracts: circleIds.flatMap((id) => [
-      {
-        address: SAVING_CIRCLES_CONTRACT_ADDRESS,
-        abi: savingCirclesAbi,
-        functionName: "circles",
-        args: [id],
-        chainId: getDefaultChainId(),
-      },
-      {
-        address: SAVING_CIRCLES_CONTRACT_ADDRESS,
-        abi: savingCirclesAbi,
-        functionName: "getCircleMembers",
-        args: [id],
-        chainId: getDefaultChainId(),
-      },
-    ]),
+    contracts: circleIds.map((id) => ({
+      address: SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS,
+      abi: savingCirclesViewerAbi,
+      functionName: "getUserCircleData",
+      args: [memberAddress, id],
+      chainId: getDefaultChainId(),
+    })),
     query: {
       enabled: circleIds.length > 0,
     },
@@ -45,49 +46,33 @@ export function useAllCircles(page: number = 0) {
   const circles: ICircleList[] = [];
 
   if (rawResults) {
-    for (let i = 0; i < circleIds.length; i++) {
-      const circleResult = rawResults[i * 2];
-      const membersResult = rawResults[i * 2 + 1];
+    const now = BigInt(Math.floor(blockTimestamp / 1000));
 
-      if (
-        circleResult.status === "failure" ||
-        membersResult.status === "failure"
-      ) {
+    for (let i = 0; i < circleIds.length; i++) {
+      const circleResult = rawResults[i];
+
+      if (circleResult.status === "failure") {
         continue;
       }
 
-      const circleData = circleResult.result as unknown as readonly [
-        owner: `0x${string}`,
-        currentIndex: bigint,
-        depositAmount: bigint,
-        token: `0x${string}`,
-        depositInterval: bigint,
-        effectiveCircleStartTime: bigint,
-        circleEnd: bigint,
-      ];
-
-      const [
-        owner,
-        currentIndex,
-        depositAmount,
-        token,
-        depositInterval,
-        effectiveCircleStartTime,
-        circleEnd,
-      ] = circleData;
-
-      const memberCount = (membersResult.result as unknown as Address[]).length;
+      const circleData = circleResult.result as unknown as UserCircleData;
+      const formattedStatus = getUserCircleStatus(
+        circleData,
+        memberAddress,
+        {},
+        now
+      );
 
       circles.push({
-        id: circleIds[i],
-        owner,
-        currentIndex,
-        depositAmount,
-        token,
-        depositInterval,
-        effectiveCircleStartTime,
-        circleEnd,
-        totalMember: memberCount,
+        ...circleData.circleInfo,
+        id: circleData.circleId,
+        totalMember: Number(circleData.totalRounds),
+        status: formattedStatus.status,
+        roundState: formattedStatus.roundState,
+        totalPoolBalance: circleData.totalPoolBalance,
+        isMember: circleData.isMember,
+        isDecommissionable: circleData.isDecommissionable,
+        userBalance: circleData.userBalance,
       });
     }
   }

--- a/src/hooks/use-user-circles-list.ts
+++ b/src/hooks/use-user-circles-list.ts
@@ -1,57 +1,392 @@
-import { useReadContract } from "wagmi";
+import { useReadContract, useReadContracts } from "wagmi";
 import { SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS } from "@/lib/constants";
 import { savingCirclesViewerAbi } from "@/lib/abis/saving-circles-viewers";
-import { Address, formatEther } from "viem";
+import { Address, formatEther, parseAbi } from "viem";
 import { ICircleList } from "@/interfaces/circle";
 import { useMemo } from "react";
 import { getDefaultChainId } from "@/utils/chain";
 import { getUserCircleStatus } from "@/lib/get-user-circle-status";
 import { useBlockTimestamp } from "./use-block-timestamp";
+import { useTotalCircles } from "./use-total-circles";
+
+type UserCircleData = Parameters<typeof getUserCircleStatus>[0];
+type FallbackCircleState = {
+  circleId: bigint;
+  circleState: number;
+  roundState: number;
+};
+type FallbackCircleInfo = Pick<
+  ICircleList,
+  | "circleEnd"
+  | "currentIndex"
+  | "depositAmount"
+  | "depositInterval"
+  | "effectiveCircleStartTime"
+  | "owner"
+  | "token"
+>;
+
+const fallbackSavingCirclesAbi = parseAbi([
+  "function getMemberCircles(address member) view returns (uint256[] ids)",
+  "function getCircle(uint256 id) view returns ((address owner,uint256 currentIndex,uint256 depositAmount,address token,uint256 depositInterval,uint256 effectiveCircleStartTime,uint256 circleEnd) circle)",
+  "function getCircleMembers(uint256 id) view returns (address[] members)",
+  "function isActive(uint256 id) view returns (bool active)",
+  "function isDecommissionable(uint256 id) view returns (bool decommissionable)",
+]);
+
+const fallbackViewerAbi = parseAbi([
+  "function getCirclesState(uint256[] circleIds) view returns ((uint256 circleId,uint8 circleState,uint8 roundState)[] states)",
+]);
+
+const CIRCLE_STATE_DECOMMISSIONED = 5;
+
+const parseCircleData = (
+  c: UserCircleData,
+  address: Address,
+  now: bigint
+): ICircleList => {
+  const totalRounds = c.totalRounds;
+  const formattedStatus = getUserCircleStatus(
+    c,
+    address,
+    { includeClaimable: true },
+    now
+  );
+
+  const circle = {
+    ...c.circleInfo,
+    totalMember: Number(totalRounds),
+    id: c.circleId,
+    status: formattedStatus.status,
+    roundState: formattedStatus.roundState,
+    totalPoolBalance: c.totalPoolBalance,
+    isMember: c.isMember,
+    isDecommissionable: c.isDecommissionable,
+    userBalance: c.userBalance,
+  };
+
+  if (c.canWithdraw) {
+    return {
+      ...circle,
+      canWithdraw: true,
+      withdrawAmount:
+        Number(formatEther(c.circleInfo.depositAmount)) * Number(totalRounds),
+    };
+  }
+
+  return {
+    ...circle,
+    canWithdraw: false,
+  };
+};
+
+const parseFallbackCircleData = ({
+  id,
+  circle,
+  members,
+  isActive,
+  isDecommissionable,
+  circleState,
+}: {
+  id: bigint;
+  circle: FallbackCircleInfo;
+  members: readonly Address[];
+  isActive: boolean;
+  isDecommissionable: boolean;
+  circleState?: FallbackCircleState;
+}): ICircleList | null => {
+  const hasStarted = circle.effectiveCircleStartTime > BigInt(0);
+  const isDecommissioned =
+    Number(circleState?.circleState) === CIRCLE_STATE_DECOMMISSIONED;
+
+  if (isDecommissioned) {
+    return {
+      ...circle,
+      id,
+      totalMember: members.length,
+      status: "decommissioned",
+      roundState: "failed",
+      totalPoolBalance: BigInt(0),
+      isMember: true,
+      isDecommissionable: false,
+      userBalance: BigInt(0),
+      canWithdraw: false,
+    };
+  }
+
+  if (isDecommissionable) {
+    return {
+      ...circle,
+      id,
+      totalMember: members.length,
+      status: "failed",
+      roundState: "failed",
+      totalPoolBalance: BigInt(0),
+      isMember: true,
+      isDecommissionable: true,
+      canWithdraw: false,
+    };
+  }
+
+  if (!hasStarted) {
+    return {
+      ...circle,
+      id,
+      totalMember: members.length,
+      status: "pending-start",
+      roundState: "not-started",
+      totalPoolBalance: BigInt(0),
+      isMember: true,
+      isDecommissionable: false,
+      canWithdraw: false,
+    };
+  }
+
+  if (!isActive) {
+    return {
+      ...circle,
+      id,
+      totalMember: members.length,
+      status: "finished",
+      roundState: "finished",
+      totalPoolBalance: BigInt(0),
+      isMember: true,
+      isDecommissionable: false,
+      userBalance: BigInt(0),
+      canWithdraw: false,
+    };
+  }
+
+  return null;
+};
 
 export function useUserCirclesList(address: Address) {
   const blockTimestamp = useBlockTimestamp();
-  const { data, isLoading, error } = useReadContract({
+  const { total: totalCircles, isLoading: loadingTotal } = useTotalCircles();
+  const circleIds = Array.from({ length: totalCircles }, (_, i) => BigInt(i));
+
+  const {
+    data: rawResults,
+    isLoading: loadingCircles,
+    error,
+  } = useReadContracts({
+    contracts: circleIds.map((id) => ({
+      address: SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS,
+      abi: savingCirclesViewerAbi,
+      functionName: "getUserCircleData",
+      args: [address, id],
+      chainId: getDefaultChainId(),
+    })),
+    query: {
+      enabled: Boolean(address) && circleIds.length > 0,
+    },
+  });
+
+  const { data: fallbackSavingCirclesAddress } = useReadContract({
     address: SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS,
     abi: savingCirclesViewerAbi,
-    functionName: "getComprehensiveUserData",
-    args: address ? [address] : undefined,
+    functionName: "SAVING_CIRCLES",
     chainId: getDefaultChainId(),
+    query: {
+      enabled: Boolean(address),
+    },
+  });
+
+  const {
+    data: memberCircleIds,
+    isLoading: loadingMemberCircleIds,
+    error: memberCircleIdsError,
+  } = useReadContract({
+    address: fallbackSavingCirclesAddress,
+    abi: fallbackSavingCirclesAbi,
+    functionName: "getMemberCircles",
+    args: [address],
+    chainId: getDefaultChainId(),
+    query: {
+      enabled: Boolean(address) && Boolean(fallbackSavingCirclesAddress),
+    },
+  });
+
+  const fallbackCircleIds = useMemo(
+    () => memberCircleIds ?? [],
+    [memberCircleIds]
+  );
+
+  const {
+    data: fallbackCircles,
+    isLoading: loadingFallbackCircles,
+    error: fallbackCirclesError,
+  } = useReadContracts({
+    contracts: fallbackCircleIds.map((id) => ({
+      address: fallbackSavingCirclesAddress!,
+      abi: fallbackSavingCirclesAbi,
+      functionName: "getCircle",
+      args: [id],
+      chainId: getDefaultChainId(),
+    })),
+    query: {
+      enabled:
+        Boolean(fallbackSavingCirclesAddress) && fallbackCircleIds.length > 0,
+    },
+  });
+
+  const {
+    data: fallbackMembers,
+    isLoading: loadingFallbackMembers,
+    error: fallbackMembersError,
+  } = useReadContracts({
+    contracts: fallbackCircleIds.map((id) => ({
+      address: fallbackSavingCirclesAddress!,
+      abi: fallbackSavingCirclesAbi,
+      functionName: "getCircleMembers",
+      args: [id],
+      chainId: getDefaultChainId(),
+    })),
+    query: {
+      enabled:
+        Boolean(fallbackSavingCirclesAddress) && fallbackCircleIds.length > 0,
+    },
+  });
+
+  const {
+    data: fallbackActiveStatuses,
+    isLoading: loadingFallbackActiveStatuses,
+    error: fallbackActiveStatusesError,
+  } = useReadContracts({
+    contracts: fallbackCircleIds.map((id) => ({
+      address: fallbackSavingCirclesAddress!,
+      abi: fallbackSavingCirclesAbi,
+      functionName: "isActive",
+      args: [id],
+      chainId: getDefaultChainId(),
+    })),
+    query: {
+      enabled:
+        Boolean(fallbackSavingCirclesAddress) && fallbackCircleIds.length > 0,
+    },
+  });
+
+  const {
+    data: fallbackDecommissionableStatuses,
+    isLoading: loadingFallbackDecommissionableStatuses,
+    error: fallbackDecommissionableStatusesError,
+  } = useReadContracts({
+    contracts: fallbackCircleIds.map((id) => ({
+      address: fallbackSavingCirclesAddress!,
+      abi: fallbackSavingCirclesAbi,
+      functionName: "isDecommissionable",
+      args: [id],
+      chainId: getDefaultChainId(),
+    })),
+    query: {
+      enabled:
+        Boolean(fallbackSavingCirclesAddress) && fallbackCircleIds.length > 0,
+    },
+  });
+
+  const {
+    data: fallbackCircleStates,
+    isLoading: loadingFallbackCircleStates,
+    error: fallbackCircleStatesError,
+  } = useReadContract({
+    address: SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS,
+    abi: fallbackViewerAbi,
+    functionName: "getCirclesState",
+    args: [fallbackCircleIds],
+    chainId: getDefaultChainId(),
+    query: {
+      enabled: fallbackCircleIds.length > 0,
+    },
   });
 
   const circles = useMemo(() => {
-    if (!data) return [];
+    if (!rawResults) return [];
 
     const now = BigInt(Math.floor(blockTimestamp / 1000));
+    const parsedCircles: ICircleList[] = [];
+    const parsedCircleIds = new Set<string>();
+    const fallbackCircleStateById = new Map(
+      (fallbackCircleStates ?? []).map((state) => [
+        state.circleId.toString(),
+        state as FallbackCircleState,
+      ])
+    );
 
-    // @ts-expect-error Correct
-    const parsedCircle: ICircleList[] = data.circleData.map((c) => {
-      const totalRounds = c.totalRounds;
+    for (const result of rawResults) {
+      if (result.status === "failure") continue;
 
-      const status = getUserCircleStatus(
-        c,
-        address,
-        { includeClaimable: true },
-        now
-      ).status;
-      const canWithdraw = c.canWithdraw;
+      const c = result.result as unknown as UserCircleData;
+      if (!c.isMember && !c.isOwner) continue;
 
-      return {
-        ...c.circleInfo,
-        totalMember: Number(totalRounds),
-        id: c.circleId,
-        status,
-        totalPoolBalance: c.totalPoolBalance,
-        canWithdraw,
-        ...(canWithdraw && {
-          withdrawAmount:
-            Number(formatEther(c.circleInfo.depositAmount)) *
-            Number(totalRounds),
-        }),
-      };
-    });
+      parsedCircles.push(parseCircleData(c, address, now));
+      parsedCircleIds.add(c.circleId.toString());
+    }
 
-    return parsedCircle;
-  }, [data]);
+    for (let i = 0; i < fallbackCircleIds.length; i++) {
+      const id = fallbackCircleIds[i];
+      const idKey = id.toString();
+      if (parsedCircleIds.has(idKey)) continue;
 
-  return { circles, isLoading, error };
+      const circleResult = fallbackCircles?.[i];
+      const membersResult = fallbackMembers?.[i];
+      const activeResult = fallbackActiveStatuses?.[i];
+      const decommissionableResult = fallbackDecommissionableStatuses?.[i];
+
+      if (
+        circleResult?.status !== "success" ||
+        membersResult?.status !== "success" ||
+        activeResult?.status !== "success" ||
+        decommissionableResult?.status !== "success"
+      ) {
+        continue;
+      }
+
+      const fallbackCircle = parseFallbackCircleData({
+        id,
+        circle: circleResult.result as unknown as FallbackCircleInfo,
+        members: membersResult.result as readonly Address[],
+        isActive: activeResult.result as boolean,
+        isDecommissionable: decommissionableResult.result as boolean,
+        circleState: fallbackCircleStateById.get(idKey),
+      });
+
+      if (!fallbackCircle) continue;
+
+      parsedCircles.push(fallbackCircle);
+      parsedCircleIds.add(idKey);
+    }
+
+    return parsedCircles;
+  }, [
+    address,
+    blockTimestamp,
+    fallbackActiveStatuses,
+    fallbackCircleIds,
+    fallbackCircleStates,
+    fallbackCircles,
+    fallbackDecommissionableStatuses,
+    fallbackMembers,
+    rawResults,
+  ]);
+
+  return {
+    circles,
+    isLoading:
+      loadingTotal ||
+      loadingCircles ||
+      loadingMemberCircleIds ||
+      loadingFallbackCircles ||
+      loadingFallbackMembers ||
+      loadingFallbackActiveStatuses ||
+      loadingFallbackDecommissionableStatuses ||
+      loadingFallbackCircleStates,
+    error:
+      error ||
+      memberCircleIdsError ||
+      fallbackCirclesError ||
+      fallbackMembersError ||
+      fallbackActiveStatusesError ||
+      fallbackDecommissionableStatusesError ||
+      fallbackCircleStatesError,
+  };
 }

--- a/src/interfaces/circle.ts
+++ b/src/interfaces/circle.ts
@@ -32,6 +32,9 @@ interface ICircleBaseList {
   token: Address;
   totalPoolBalance?: bigint;
   roundState?: ICircleRoundState;
+  isMember?: boolean;
+  isDecommissionable?: boolean;
+  userBalance?: bigint;
 }
 
 type ICircleWithdraw = {

--- a/src/interfaces/circle.ts
+++ b/src/interfaces/circle.ts
@@ -13,6 +13,13 @@ export type ICircleStatus =
   | "payment_due"
   | "in-progress";
 
+export type ICircleRoundState =
+  | "not-started"
+  | "in-progress"
+  | "deposits-complete"
+  | "finished"
+  | "failed";
+
 interface ICircleBaseList {
   circleEnd: bigint;
   currentIndex: bigint;
@@ -24,6 +31,7 @@ interface ICircleBaseList {
   owner: Address;
   token: Address;
   totalPoolBalance?: bigint;
+  roundState?: ICircleRoundState;
 }
 
 type ICircleWithdraw = {

--- a/src/lib/get-user-circle-status.ts
+++ b/src/lib/get-user-circle-status.ts
@@ -1,11 +1,13 @@
 import { AlertProps } from "@/components/alert";
 import { useUserCircleData } from "@/hooks/use-user-circle-data";
-import { ICircleStatus } from "@/interfaces/circle";
+import { ICircleRoundState, ICircleStatus } from "@/interfaces/circle";
 import { HandDepositIcon, Icon } from "@phosphor-icons/react";
 import { Address } from "viem";
 
 export interface IFormattedUserCircleStatusResult {
   status: ICircleStatus;
+  roundState: ICircleRoundState;
+  roundStateLabel: string;
   statusLabel: string;
   variant: AlertProps["variant"];
   title: string;
@@ -17,6 +19,14 @@ interface GetUserCircleStatusConfig {
   includeDeposited?: boolean;
   includeClaimable?: boolean;
 }
+
+const roundStateLabels: Record<ICircleRoundState, string> = {
+  "not-started": "Not started",
+  "in-progress": "In progress",
+  "deposits-complete": "Deposits complete",
+  finished: "Finished",
+  failed: "Failed",
+};
 
 export const getUserCircleStatus = (
   circle: Exclude<
@@ -39,10 +49,17 @@ export const getUserCircleStatus = (
     depositWindowOpen &&
     !hasDepositedThisRound;
   const completedRounds = circle.completedRounds;
+  const hasStarted = circle.circleInfo.effectiveCircleStartTime > BigInt(0);
+  const isCompleted =
+    hasStarted &&
+    completedRounds >= circle.totalRounds &&
+    circle.totalPoolBalance === BigInt(0);
 
   if (circle.isDecommissioned) {
     return {
       status: "decommissioned",
+      roundState: "failed",
+      roundStateLabel: roundStateLabels.failed,
       statusLabel: "Decommissioned",
       variant: "stop",
       title: "Circle has been decommissioned",
@@ -50,9 +67,11 @@ export const getUserCircleStatus = (
     };
   }
 
-  if (circle.circleInfo.effectiveCircleStartTime === BigInt(0)) {
+  if (!hasStarted) {
     return {
       status: "pending-start",
+      roundState: "not-started",
+      roundStateLabel: roundStateLabels["not-started"],
       statusLabel: "Not started",
       variant: "warning",
       title: isOwner
@@ -64,29 +83,11 @@ export const getUserCircleStatus = (
     };
   }
 
-  // Finished: currentIndex (completedRounds) reset to 0 after full cycle, started, decommissionable, and no pool balance (balances cleared)
-  if (
-    completedRounds === BigInt(0) &&
-    circle.circleInfo.effectiveCircleStartTime > BigInt(0) &&
-    circle.isDecommissionable &&
-    circle.totalPoolBalance === BigInt(0)
-  ) {
-    return {
-      status: "finished",
-      statusLabel: "Finished",
-      variant: "success",
-      title: "Circle completed successfully",
-      desc: "Everyone has deposited and withdrawn their funds. No more actions can be taken.",
-    };
-  }
-
-  // Failed: decommissionable (past window with incomplete deposits), either non-zero index or pool balance >0 (funds locked)
-  if (
-    circle.isDecommissionable &&
-    (completedRounds > BigInt(0) || circle.totalPoolBalance > BigInt(0))
-  ) {
+  if (circle.isDecommissionable) {
     return {
       status: "failed",
+      roundState: "failed",
+      roundStateLabel: roundStateLabels.failed,
       statusLabel: "Failed",
       variant: "stop",
       title: "Circle has failed",
@@ -94,10 +95,23 @@ export const getUserCircleStatus = (
     };
   }
 
-  // Expired but still actionable (e.g., final claim possible)
+  if (isCompleted) {
+    return {
+      status: "finished",
+      roundState: "finished",
+      roundStateLabel: roundStateLabels.finished,
+      statusLabel: "Finished",
+      variant: "success",
+      title: "Circle completed successfully",
+      desc: "Everyone has deposited and withdrawn their funds. No more actions can be taken.",
+    };
+  }
+
   if (circle.isExpired) {
     return {
       status: "expired",
+      roundState: "failed",
+      roundStateLabel: roundStateLabels.failed,
       statusLabel: "Expired",
       variant: "warning",
       title: "Circle has expired",
@@ -108,6 +122,8 @@ export const getUserCircleStatus = (
   if (config.includeClaimable && circle.canWithdraw) {
     return {
       status: "claimable",
+      roundState: "deposits-complete",
+      roundStateLabel: roundStateLabels["deposits-complete"],
       statusLabel: "Claimable",
       variant: "success",
       title: "It's your turn to claim",
@@ -122,7 +138,9 @@ export const getUserCircleStatus = (
   ) {
     return {
       status: "deposit-completed",
-      statusLabel: "Deposits Completed",
+      roundState: "deposits-complete",
+      roundStateLabel: roundStateLabels["deposits-complete"],
+      statusLabel: "Deposits complete",
       variant: "success",
       title: "Round deposits complete",
       desc: "Waiting for the eligible member to claim this round's payout.",
@@ -132,6 +150,8 @@ export const getUserCircleStatus = (
   if (config.includeDeposited && hasDepositedThisRound) {
     return {
       status: "deposited",
+      roundState: "in-progress",
+      roundStateLabel: roundStateLabels["in-progress"],
       statusLabel: "Deposited",
       variant: "success",
       title: "Your deposit is complete",
@@ -143,6 +163,8 @@ export const getUserCircleStatus = (
   if (canDeposit) {
     return {
       status: "payment_due",
+      roundState: "in-progress",
+      roundStateLabel: roundStateLabels["in-progress"],
       statusLabel: "Payment Due",
       variant: "warning",
       title: "Deposit required",
@@ -152,6 +174,8 @@ export const getUserCircleStatus = (
 
   return {
     status: "in-progress",
+    roundState: "in-progress",
+    roundStateLabel: roundStateLabels["in-progress"],
     statusLabel: "In Progress",
     variant: "success",
     title: "Circle is in progress",


### PR DESCRIPTION
This PR reorganizes stack lifecycle handling around five states ([figma](https://www.figma.com/design/CsleaPTgZVQXwkYnfUnUSE/Bread-Stacks?node-id=2532-28955&t=9APIUM5GZdG4EK7D-1)):

- Not started
- In progress
- Deposits complete
- Finished
- Failed

It also updates the dashboard so stack cards, tabs, filters, and actions match those states.

Main changes:

- Add normalized `roundState` and `roundStateLabel` alongside existing statuses.
- Load all stack cards through viewer user data so cards include membership, balance, and recovery context.
- Recover missing user stacks by merging viewer results with core contract membership fallback reads (see reason at the end of description).
- Add pagination/filtering support for the all-stacks dashboard list.
- Restore the logged-in dashboard section with the user stack tabs.
- Update user stack filters:
    - Due shows stacks requiring deposit.
    - Claim shows claimable stacks and failed stacks with recoverable balance.
    - Past uses normalized terminal round states.
- Adapt dashboard cards to show the right CTA:
    - Deposit button for payment due.
    - Claim button for claimable rounds.
    - Failed recovery action when the user can claim undistributed deposits.
    - Completed/failed terminal states when no action is available.
- Update detail views so failed/finished states do not show misleading countdowns, progress, or rounds-left values.

Backend note:

The frontend currently needs fallback core-contract reads because the viewer does not expose one canonical list of all user-relevant stacks, especially historical, failed, or decommissioned member stacks.

Ideally, the backend/viewer should expose a single user stacks method that returns normalized lifecycle state plus separate action flags like canDeposit, canWithdraw, canDecommission, and hasRecoverableBalance. That would let the frontend remove the fallback merge logic and avoid deriving lifecycle state from multiple partial sources.