### PR TITLE
feat: warn before starting stack with missing members

### DIFF
--- a/src/app/stacks/[id]/_components/overview.tsx
+++ b/src/app/stacks/[id]/_components/overview.tsx
@@ -61,10 +61,8 @@ const Overview = ({
     { includeDeposited: true },
     nowSeconds
   );
-  const { data: stackMetadata } = useStackSupabase(
-    circle.circleId.toString(),
-    circle.isMember
-  );
+  const { data: stackMetadata, isLoading: isStackMetadataLoading } =
+    useStackSupabase(circle.circleId.toString(), circle.isMember);
 
   const nonceChecks = (stackMetadata?.invite_links ?? [])
     .map((link) => {
@@ -97,6 +95,7 @@ const Overview = ({
   const expectedMembers = stackMetadata?.expected_members ?? 0;
   const acceptedMembers = Number(circle.totalRounds);
   const hasEnoughMembersToStart = acceptedMembers >= 2;
+  const membersNeededToStart = Math.max(2 - acceptedMembers, 0);
   const hasInviteMetadata = expectedMembers > 0 || nonceChecks.length > 0;
   const inviteStatusReady =
     nonceChecks.length === 0 || nonceResults?.length === nonceChecks.length;
@@ -108,10 +107,23 @@ const Overview = ({
         return result.result === false;
       }).length
     : nonceChecks.length;
+  const expectedPendingMembers = Math.max(expectedMembers - acceptedMembers, 0);
+  const pendingMembersToJoin = Math.max(
+    pendingInvites,
+    expectedPendingMembers,
+    membersNeededToStart
+  );
+  const missingExpectedOrInvitedMembers = Math.max(
+    pendingInvites,
+    expectedPendingMembers
+  );
 
   const invitesComplete = hasInviteMetadata
-    ? hasEnoughMembersToStart && inviteStatusReady && pendingInvites === 0
+    ? hasEnoughMembersToStart && inviteStatusReady && pendingMembersToJoin === 0
     : hasEnoughMembersToStart;
+  const canResolveMissingMembers = !isStackMetadataLoading && inviteStatusReady;
+  const shouldWarnBeforeStart =
+    hasInviteMetadata && missingExpectedOrInvitedMembers > 0;
 
   const totalMembers =
     formattedCircleStatus.status === "pending-start"
@@ -225,21 +237,28 @@ const Overview = ({
       <div className="mt-4">
         {formattedCircleStatus.status === "pending-start" ? (
           <>
-            {!invitesComplete && circle.isMember ? (
-              <Body className="text-center text-surface-grey">
-                Waiting for{" "}
-                <span className="font-bold text-surface-ink">
-                  {pendingInvites}
-                </span>{" "}
-                {pendingInvites === 1 ? "invite" : "invites"} to be accepted
-                before the stack can start.
-              </Body>
-            ) : member === circle.circleInfo.owner ? (
+            {member === circle.circleInfo.owner &&
+            hasEnoughMembersToStart &&
+            canResolveMissingMembers ? (
               <StartCircleButton
                 circleId={BigInt(circle.circleId)}
                 amount={circle.circleInfo.depositAmount}
+                pendingMembers={
+                  shouldWarnBeforeStart ? missingExpectedOrInvitedMembers : 0
+                }
                 width="full"
               />
+            ) : member === circle.circleInfo.owner &&
+              hasEnoughMembersToStart ? (
+              <LiftedButton width="full" className="text-paper-main" disabled>
+                Checking members...
+              </LiftedButton>
+            ) : !invitesComplete && circle.isMember ? (
+              <Body className="text-center text-surface-grey">
+                {pendingMembersToJoin} invited{" "}
+                {pendingMembersToJoin === 1 ? "member has" : "members have"} not
+                joined yet.
+              </Body>
             ) : (
               <LiftedButton width="full" className="text-paper-main" disabled>
                 Stack creator needs to start stack

--- a/src/components/modal/context.tsx
+++ b/src/components/modal/context.tsx
@@ -77,6 +77,12 @@ export type StackFailedModalState = {
   id: bigint;
 };
 
+export type StartStackWarningModalState = {
+  type: "START_STACK_WARNING";
+  pendingMembers: number;
+  onConfirm: () => void;
+};
+
 export type WithdrawBreadModalState = {
   type: "WITHDRAW_BREAD";
 };
@@ -129,6 +135,7 @@ export type ModalState =
   | StackInitSuccessModalState
   | StackInitFailedModalState
   | StackFailedModalState
+  | StartStackWarningModalState
   | WithdrawBreadModalState
   | WalletFundingStatusModalState
   | ReminderModalState

--- a/src/components/modal/modals/start-stack-warning.tsx
+++ b/src/components/modal/modals/start-stack-warning.tsx
@@ -1,0 +1,48 @@
+import { Body, LiftedButton } from "@breadcoop/ui";
+import { ModalContainer, ModalHeader } from "../components";
+import { StartStackWarningModalState, useModal } from "../context";
+import LocalLiftedButton from "@/components/lifted-button";
+
+const StartStackWarningModal = ({
+  modalState,
+}: {
+  modalState: StartStackWarningModalState;
+}) => {
+  const { setModal } = useModal();
+
+  const startStack = () => {
+    setModal(null);
+    modalState.onConfirm();
+  };
+
+  return (
+    <ModalContainer>
+      <ModalHeader title="Start stack now?" />
+      <Body className="text-center text-surface-grey">
+        {modalState.pendingMembers === 1
+          ? "1 invited member has not joined yet."
+          : `${modalState.pendingMembers} invited members have not joined yet.`}{" "}
+        Once the stack starts, no one else can join.
+      </Body>
+      <div className="flex flex-col gap-3">
+        <LocalLiftedButton
+          width="full"
+          className="font-bold"
+          onClick={startStack}
+        >
+          Start Stacks
+        </LocalLiftedButton>
+        <LiftedButton
+          preset="burn"
+          width="full"
+          className="font-bold text-system-red"
+          onClick={() => setModal(null)}
+        >
+          Cancel
+        </LiftedButton>
+      </div>
+    </ModalContainer>
+  );
+};
+
+export default StartStackWarningModal;

--- a/src/components/modal/presenter.tsx
+++ b/src/components/modal/presenter.tsx
@@ -20,6 +20,7 @@ import FundWallet from "./modals/fund-wallet/fund-wallet";
 import LiFiSwapModal from "../lifi/swap-modal";
 import InstallPeerModal from "../peer/install-modal";
 import FundWithConnectedWalletModalAmount from "./modals/fund-wallet/fund-with-connected-wallet-modal-amount";
+import StartStackWarningModal from "./modals/start-stack-warning";
 
 const ModalPresenter = () => {
   const { modalState, setModal } = useModal();
@@ -59,6 +60,9 @@ const ModalPresenter = () => {
               )}
               {modalState.type === "STACK_FAILED" && (
                 <StackFailed modalState={modalState} />
+              )}
+              {modalState.type === "START_STACK_WARNING" && (
+                <StartStackWarningModal modalState={modalState} />
               )}
               {modalState.type === "WITHDRAW_BREAD" && <WithdrawBreadModal />}
               {modalState.type === "NEW_USER_ONBOARDING" && (

--- a/src/components/start-circle-button.tsx
+++ b/src/components/start-circle-button.tsx
@@ -8,10 +8,12 @@ import { useQueryClient } from "@tanstack/react-query";
 import Loading from "@/app/loading";
 import { useSavingCirclesTx } from "@/hooks/use-saving-circles-tx";
 import { parseContractError } from "@/utils/parse-contract-error";
+import { useModal } from "./modal/context";
 
 interface StartCircleButtonProps extends Omit<LiftedButtonProps, "children"> {
   amount: bigint;
   circleId: bigint;
+  pendingMembers?: number;
 }
 
 const START_ERRORS: Record<string, string> = {
@@ -28,10 +30,12 @@ const parseStartError = (error: unknown) =>
 const StartCircleButton = ({
   amount,
   circleId,
+  pendingMembers = 0,
   ...props
 }: StartCircleButtonProps) => {
   const { sendSavingCirclesTx } = useSavingCirclesTx();
   const queryClient = useQueryClient();
+  const { setModal } = useModal();
   const [starting, setStarting] = useState(false);
 
   const start = async () => {
@@ -52,11 +56,24 @@ const StartCircleButton = ({
     }
   };
 
+  const onClick = () => {
+    if (pendingMembers > 0) {
+      setModal({
+        type: "START_STACK_WARNING",
+        pendingMembers,
+        onConfirm: start,
+      });
+      return;
+    }
+
+    start();
+  };
+
   return (
     <div className="flex flex-col gap-1">
       <LocalLiftedButton
         {...props}
-        onClick={start}
+        onClick={onClick}
         className={`${props.className || ""} font-semibold`}
       >
         {starting ? (


### PR DESCRIPTION
## Summary

Adds a warning modal when the stack creator starts a stack before all expected members have joined.

## Changes

- Shows confirmation modal only when members are still missing.
- Lets the creator cancel or confirm starting the stack.
- Prevents starting while member/invite status is still loading.

