### PR TITLE
feat: add hover states to deposit module

### DIFF
--- a/src/components/modal/modals/fund-wallet/fund-button.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-button.tsx
@@ -20,7 +20,7 @@ const FundButton = ({
   return (
     <button
       type="button"
-      className="border border-paper-2 bg-paper-0 flex items-center justify-start gap-4 py-2.5 px-5 cursor-pointer w-full"
+      className="border border-paper-2 bg-paper-0 flex items-center justify-start gap-4 py-2.5 px-5 cursor-pointer w-full transition-colors hover:border-primary-blue hover:bg-blue-0"
       onClick={onClick}
     >
       <figure className="w-8 h-8 flex items-center justify-center">

--- a/src/components/modal/modals/fund-wallet/fund-wallet.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-wallet.tsx
@@ -71,7 +71,7 @@ const FundWallet = ({ modalState }: { modalState: FundWalletModalState }) => {
         {modalState.showSkipProcess && (
           <button
             type="button"
-            className="font-bold text-primary-blue mt-6"
+            className="font-bold text-primary-blue mt-6 transition-colors hover:text-blue-2 cursor-pointer"
             onClick={handleSkip}
           >
             Skip this process


### PR DESCRIPTION
## Summary

Adds hover states to the **Fund your account** deposit module (the modal that opens from "Fund Stacks wallet" after a Privy wallet is connected).

## Changes

- **`FundButton`** (shared by both funding options — "Wallet" and "Transfer crypto"): on hover, the card gets a light-blue fill (`blue-0` / `#a8c3ea`) and a `primary-blue` border (`#1c5bb9`), with `transition-colors` for a smooth fade. Matches the bordered-card hover convention already used by `accordion.tsx`.
- **"Skip this process" link**: text darkens to `blue-2` (`#1b4a90`) on hover with `transition-colors` — the same primary-blue → blue-2 hover the design system uses for its primary button preset. Also added `cursor-pointer`.

## Verification

- All color tokens confirmed present in the `@breadcoop/ui` theme.
- ESLint passes on both files.
- Live hover is best checked on the deploy preview: connect a Privy wallet → "Fund Stacks wallet" → hover the two funding options and the Skip link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)