### PR TITLE
feat: add hover and selected states to navbar menu items

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -2,6 +2,7 @@ import { Navbar as LibNavbar } from "@breadcoop/ui";
 import Link from "next/link";
 import WidgetItems from "./widget-items";
 import ActionItems from "./action-items";
+import NavLinks from "./nav-links";
 
 export function Navbar() {
   return (
@@ -12,14 +13,7 @@ export function Navbar() {
       actionItems={<ActionItems />}
       Link={Link}
     >
-      <nav className="flex flex-col gap-2 md:flex-row md:gap-4 md:mr-8">
-        <Link href="/" className="text-body">
-          Dashboard
-        </Link>
-        <Link href="/new" className="text-body">
-          Start stacks group
-        </Link>
-      </nav>
+      <NavLinks />
     </LibNavbar>
   );
 }

--- a/src/components/Navbar/nav-links.tsx
+++ b/src/components/Navbar/nav-links.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/", label: "Dashboard" },
+  { href: "/new", label: "Start stacks group" },
+];
+
+const NavLinks = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-col gap-2 md:mr-8 md:flex-row md:gap-4">
+      {links.map(({ href, label }) => {
+        const isActive = pathname === href;
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "text-body transition-colors hover:text-primary-blue",
+              isActive && "font-bold text-primary-blue"
+            )}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default NavLinks;


### PR DESCRIPTION
## What & why

Adds hover and selected states to the navbar menu items. On hover, a menu item turns **stacks blue** (`primary-blue`); the **selected** item (the current route) is also shown in stacks blue (and bold) so users can see where they are.

## Changes

- New client component [`nav-links.tsx`](src/components/Navbar/nav-links.tsx) — renders the menu links and tracks the active route via `usePathname`.
  - `hover:text-primary-blue` + `transition-colors` on every item.
  - Active item: `text-primary-blue font-bold`, with `aria-current="page"` for accessibility.
- [`Navbar.tsx`](src/components/Navbar/Navbar.tsx) now renders `<NavLinks />` instead of the inline `<nav>`.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` — clean
- Netlify deploy preview builds the branch; the navbar is visible on every page, so hover/selected are checkable directly on the preview.

## Notes
- Active match is exact (`pathname === href`), so "Dashboard" highlights only on `/` and "Start stacks group" only on `/new`.
- Heads-up on overlap: PR #115 adds a "My Account" link to this same nav. Whichever merges second, the new link just needs adding to the `links` array here — happy to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
