### PR TITLE
fix: refresh circle state after claim to avoid stale UI

### DIFF
--- a/src/components/claim-button.tsx
+++ b/src/components/claim-button.tsx
@@ -7,10 +7,11 @@ import { useModal } from "./modal/context";
 import { cn } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { Address } from "viem";
-import { formatBalance } from "@breadcoop/ui";
+import { formatBalance, useConnectedUser } from "@breadcoop/ui";
 import { useSavingCirclesTx } from "@/hooks/use-saving-circles-tx";
 import { parseContractError } from "@/utils/parse-contract-error";
 import { CLAIM_ERRORS } from "@/lib/contract-errors";
+import { refetchAfterClaim } from "@/utils/refetch-after-claim";
 
 const parseClaimError = (error: unknown) =>
   parseContractError(error, CLAIM_ERRORS, "Failed to claim. Please try again.");
@@ -36,6 +37,11 @@ const ClaimButton = ({
   const { setModal } = useModal();
   const [claiming, setClaiming] = useState(false);
   const { sendSavingCirclesTx } = useSavingCirclesTx();
+  const { user } = useConnectedUser();
+  const member =
+    user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN"
+      ? user.address
+      : undefined;
 
   console.log({ nextDeposit, roundsLeft, nextDepositAddress });
 
@@ -51,8 +57,12 @@ const ClaimButton = ({
         args: [circleId],
       });
 
-      queryClient.invalidateQueries({ queryKey: ["readContract"] });
-      queryClient.invalidateQueries({ queryKey: ["readContracts"] });
+      if (member) {
+        await refetchAfterClaim(queryClient, { circleId, member });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ["readContract"] });
+        queryClient.invalidateQueries({ queryKey: ["readContracts"] });
+      }
 
       setModal({
         type: "CLAIM_RESULT",

--- a/src/utils/refetch-after-claim.ts
+++ b/src/utils/refetch-after-claim.ts
@@ -1,0 +1,44 @@
+import { readContract } from "@wagmi/core";
+import { QueryClient } from "@tanstack/react-query";
+import { Address } from "viem";
+import { wagmiConfig } from "@/components/providers/web3";
+import { savingCirclesViewerAbi } from "@/lib/abis/saving-circles-viewers";
+import { SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS } from "@/lib/constants";
+import { getDefaultChainId } from "@/utils/chain";
+
+/**
+ * After a successful claim, the viewer can briefly still report the pre-claim
+ * state (read-after-write RPC lag), so a single invalidate repopulates the cache
+ * with stale data and the UI gets stuck on "Awaiting current withdrawer to claim".
+ *
+ * Poll the viewer directly until `canWithdraw` flips to false (the claimer has
+ * claimed), then invalidate so every mounted query refetches fresh data.
+ */
+export async function refetchAfterClaim(
+  queryClient: QueryClient,
+  {
+    circleId,
+    member,
+    attempts = 6,
+    delayMs = 1200,
+  }: { circleId: bigint; member: Address; attempts?: number; delayMs?: number }
+) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const data = await readContract(wagmiConfig, {
+        address: SAVING_CIRCLES_VIEWER_CONTRACT_ADDRESS,
+        abi: savingCirclesViewerAbi,
+        functionName: "getUserCircleData",
+        args: [member, circleId],
+        chainId: getDefaultChainId(),
+      });
+      if (data?.canWithdraw === false) break;
+    } catch {
+      // ignore and retry — the next poll will pick up the settled state
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  await queryClient.invalidateQueries({ queryKey: ["readContract"] });
+  await queryClient.invalidateQueries({ queryKey: ["readContracts"] });
+}


### PR DESCRIPTION
## Problem

Closes #91.

After a successful claim, the UI gets stuck on "Awaiting current withdrawer to claim" (and the next-round deposit prompt never appears) until the user manually refreshes the page.

### Root cause

The claim path already waits for the tx receipt and invalidates the `readContract`/`readContracts` caches — so the issue's original diagnosis ("missing invalidation") is no longer accurate. The real problem is **read-after-write RPC lag**: right after `withdraw` is mined, the immediate refetch's `eth_call` can still read the pre-claim block, so the single invalidate repopulates the cache with **stale** state. All circle state comes from one source (`getUserCircleData` on the viewer), so the whole page stays stale until a full reload.

This is purely a data-freshness bug — with fresh data the existing status logic already resolves correctly (the "Awaiting current withdrawer" branch only fires when the pool reads as still-full).

## Fix

Replace the fire-and-forget invalidate in `claim-button.tsx` with `refetchAfterClaim`: poll the viewer directly until `canWithdraw` flips to `false` (deterministic post-claim signal), then invalidate so every mounted query refetches fresh data. Falls back to the previous invalidate if no connected member address is available.

## Scope

- `src/utils/refetch-after-claim.ts` (new helper)
- `src/components/claim-button.tsx` (wire it in)

No contract, status-logic, or UI-structure changes.

## Verification

- `tsc` + `eslint` clean on changed files; pre-commit `next lint` passed.
- Manual: claim on your turn and confirm the page leaves the stale "Awaiting current withdrawer" state and shows the correct current-round state **without** a manual refresh.

> Note: this only makes the UI reflect true on-chain state. Depositing for the next round remains time-gated by the contract (`_currentRoundIndex` is time-based), so it does not — and should not — enable an early deposit.