### PR TITLE
feat: add claim schedule component to the Stack page

### DIFF
--- a/src/app/stacks/[id]/_components/claim-schedule.tsx
+++ b/src/app/stacks/[id]/_components/claim-schedule.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { Fragment, useRef } from "react";
+import { Address } from "viem";
+import { Body, Heading3 } from "@breadcoop/ui";
+import {
+  ArrowRightIcon,
+  CalendarDotsIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
+  CheckCircleIcon,
+  CircleIcon,
+} from "@phosphor-icons/react";
+import { useCircleMembersWithBalances } from "@/hooks/use-circle-members";
+import { usePreferredEnsName } from "@/hooks/use-preferred-ens-name";
+import { useUserCircleData } from "@/hooks/use-user-circle-data";
+import { formatAddress } from "@/utils/address";
+import { cn } from "@/lib/utils";
+
+type CircleData = NonNullable<
+  ReturnType<typeof useUserCircleData>["circleData"]
+>;
+
+type TurnStatus = "completed" | "current" | "upcoming";
+
+const SECONDS_PER_DAY = 86_400;
+
+// dd/mm/yyyy, matching the rest of the app (en-GB).
+const formatDate = (seconds: number) =>
+  new Intl.DateTimeFormat("en-GB").format(new Date(seconds * 1000));
+
+const ClaimSchedule = ({
+  id,
+  circle,
+  member,
+  now,
+}: {
+  id: string;
+  circle: CircleData;
+  /** The connected member's address. */
+  member: Address;
+  /** Current time in milliseconds (block timestamp). */
+  now: number;
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { members, isLoading } = useCircleMembersWithBalances(BigInt(id));
+
+  const { circleInfo } = circle;
+  const startTime = Number(circleInfo.effectiveCircleStartTime);
+  const interval = Number(circleInfo.depositInterval);
+  const currentIndex = Number(circleInfo.currentIndex);
+  const nowSeconds = Math.floor(now / 1000);
+
+  // Round i's turn date = circle start + one interval per preceding round.
+  const turnDate = (index: number) => startTime + interval * index;
+
+  const turnStatus = (index: number): TurnStatus => {
+    if (index < currentIndex) return "completed";
+    if (index === currentIndex) return "current";
+    return "upcoming";
+  };
+
+  const scroll = (direction: -1 | 1) =>
+    scrollRef.current?.scrollBy({ left: direction * 232, behavior: "smooth" });
+
+  const youIndex = members.findIndex(
+    (address) => address.toLowerCase() === member.toLowerCase()
+  );
+
+  // "You can claim in": use the contract's per-user nextWithdrawTime when set,
+  // otherwise fall back to the start of the member's own round.
+  const claimCountdown = (): { value: string; unit: string } => {
+    if (youIndex < 0) return { value: "—", unit: "" };
+    if (youIndex < currentIndex) return { value: "Claimed", unit: "" };
+
+    const nextWithdraw = Number(circle.nextWithdrawTime);
+    const target = nextWithdraw > 0 ? nextWithdraw : turnDate(youIndex);
+    const days = Math.max(
+      0,
+      Math.ceil((target - nowSeconds) / SECONDS_PER_DAY)
+    );
+    return { value: String(days), unit: days === 1 ? "Day" : "Days" };
+  };
+
+  const countdown = claimCountdown();
+
+  return (
+    <section className="bg-paper-0 flex flex-col gap-4 p-4 md:p-6">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <Heading3 className="text-2xl leading-[100%]">Claim schedule</Heading3>
+        <div className="flex items-center gap-1.5">
+          <Body className="text-surface-grey-2">Created on:</Body>
+          <CalendarDotsIcon size={20} className="fill-blue-2" />
+          <Body className="text-surface-ink">{formatDate(startTime)}</Body>
+        </div>
+      </header>
+
+      <div className="flex items-center gap-2 border-t border-paper-2 pt-4">
+        <button
+          type="button"
+          aria-label="Scroll schedule left"
+          onClick={() => scroll(-1)}
+          className="shrink-0 rounded-md border border-surface-ink p-2 transition-colors hover:bg-paper-2"
+        >
+          <CaretLeftIcon size={20} className="fill-surface-ink" />
+        </button>
+
+        <div
+          ref={scrollRef}
+          className="flex grow items-stretch gap-3 overflow-x-auto scrollbar-hidden py-2"
+        >
+          {isLoading ? (
+            <Body className="text-surface-grey-2 py-8">
+              Loading claim schedule…
+            </Body>
+          ) : (
+            members.map((address, index) => {
+              const status = turnStatus(index);
+              const isCurrent = status === "current";
+              const isYou = address.toLowerCase() === member.toLowerCase();
+
+              return (
+                <Fragment key={address}>
+                  <div
+                    className={cn(
+                      "relative flex w-36 shrink-0 flex-col items-center gap-2 rounded-xl p-3 pt-7 text-center",
+                      isCurrent
+                        ? "border-2 border-primary-blue bg-blue-0"
+                        : "bg-paper-2"
+                    )}
+                  >
+                    {status === "completed" && (
+                      <span className="absolute top-2 flex items-center gap-1 text-xs font-bold text-system-green">
+                        <CheckCircleIcon
+                          size={16}
+                          className="fill-system-green"
+                        />
+                        Completed
+                      </span>
+                    )}
+                    {status === "current" && (
+                      <span className="absolute top-2 flex items-center gap-1 text-xs font-bold text-primary-blue">
+                        <CircleIcon size={16} className="fill-primary-blue" />
+                        Current turn
+                      </span>
+                    )}
+
+                    <span
+                      className={cn(
+                        "text-4xl font-extrabold",
+                        status === "upcoming"
+                          ? "text-surface-grey-2"
+                          : isCurrent
+                            ? "text-primary-blue"
+                            : "text-surface-ink"
+                      )}
+                    >
+                      #{index + 1}
+                    </span>
+
+                    <Body
+                      className={cn(
+                        "max-w-full truncate",
+                        status === "upcoming"
+                          ? "text-surface-grey-2"
+                          : "text-surface-ink"
+                      )}
+                    >
+                      <ScheduleMemberName address={address} isYou={isYou} />
+                    </Body>
+
+                    <span className="flex items-center gap-1 text-sm text-blue-2">
+                      <CalendarDotsIcon size={16} className="fill-blue-2" />
+                      {formatDate(turnDate(index))}
+                    </span>
+                  </div>
+
+                  {index < members.length - 1 && (
+                    <ArrowRightIcon
+                      size={20}
+                      className="shrink-0 self-center fill-primary-blue"
+                    />
+                  )}
+                </Fragment>
+              );
+            })
+          )}
+        </div>
+
+        <button
+          type="button"
+          aria-label="Scroll schedule right"
+          onClick={() => scroll(1)}
+          className="shrink-0 rounded-md border border-surface-ink p-2 transition-colors hover:bg-paper-2"
+        >
+          <CaretRightIcon size={20} className="fill-surface-ink" />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-paper-2 pt-4 md:flex-row md:gap-4">
+        <div className="flex flex-1 items-center justify-between rounded-lg bg-paper-2 px-4 py-3">
+          <Body className="text-surface-grey-2">Your claim order</Body>
+          <Body className="text-xl font-bold text-surface-ink">
+            {youIndex >= 0 ? `#${youIndex + 1}` : "—"}
+          </Body>
+        </div>
+        <div className="flex flex-1 items-center justify-between rounded-lg bg-paper-2 px-4 py-3">
+          <Body className="text-surface-grey-2">You can claim in</Body>
+          <Body className="text-surface-ink">
+            <span className="text-xl font-bold">{countdown.value}</span>
+            {countdown.unit ? ` ${countdown.unit}` : ""}
+          </Body>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+function ScheduleMemberName({
+  address,
+  isYou,
+}: {
+  address: Address;
+  isYou: boolean;
+}) {
+  const { ensName, isLoading } = usePreferredEnsName({ address });
+  const name = isLoading ? "Loading…" : ensName || formatAddress(address);
+
+  return (
+    <>
+      {name}
+      {isYou ? " (You)" : ""}
+    </>
+  );
+}
+
+export default ClaimSchedule;

--- a/src/app/stacks/[id]/_components/page-content.tsx
+++ b/src/app/stacks/[id]/_components/page-content.tsx
@@ -5,6 +5,7 @@ import StackHeader from "./header";
 import StackDetails from "./stack-details";
 import StackMembers from "./members";
 import StackInfo from "./info";
+import ClaimSchedule from "./claim-schedule";
 import { CircularProgressIcon } from "@/components/icons/circular-progress";
 import { Body, useConnectedUser } from "@breadcoop/ui";
 import StackedStatus from "./stacked-status";
@@ -74,6 +75,14 @@ const PageContent = ({ id }: { id: string }) => {
               member={member}
             />
             <StackDetails id={id} circle={userCircleData.circleData} />
+            {userCircleData.circleData.isMember && (
+              <ClaimSchedule
+                id={id}
+                circle={userCircleData.circleData}
+                member={member}
+                now={now}
+              />
+            )}
             <StackMembers
               id={id}
               circle={userCircleData.circleData.circleInfo}


### PR DESCRIPTION
Closes #112

## Summary
Adds a **members-only "Claim schedule"** section to the Stack page (`/stacks/[id]`) so members can see, at a glance, each member's claim turn/order and when their own turn is coming up. Per the issue, users found it hard to tell when it's their turn — the claim order (the order members joined the circle) wasn't surfaced anywhere.

Design reference (Figma node `2998-1954` / prototype `2874-3921`):

| State | Behaviour |
|------|-----------|
| Past rounds | **Completed** badge (green) |
| Current round | **Current turn** badge, card highlighted blue |
| Future rounds | Greyed, upcoming |

## What it does
- **Horizontal, scrollable row of member cards** (`#1`, `#2`, …) in claim order, with prev/next nav buttons and arrows between cards.
- **Per-card status** derived from `circleInfo.currentIndex`: completed / current / upcoming.
- **Per-card claim date** = `effectiveCircleStartTime + depositInterval * index`, and a **"Created on"** date in the header — both formatted `dd/mm/yyyy` (en-GB), matching the rest of the app.
- **Member identity**: ENS name when available, otherwise shortened address (reuses `usePreferredEnsName` + `formatAddress`), with **"(You)"** appended for the connected member.
- **Footer**: "Your claim order  #N" and "You can claim in N days" (from the contract's per-user `nextWithdrawTime`, falling back to the member's round start).

## Members-only
The section is gated in `page-content.tsx` and only renders when `userCircleData.circleData.isMember` is `true`.

## Files
- `src/app/stacks/[id]/_components/claim-schedule.tsx` — new component (`"use client"`).
- `src/app/stacks/[id]/_components/page-content.tsx` — import + render (member-gated), placed after Stack details.

## Assumptions worth a sanity-check (flagging per repo conventions)
1. **Claim date semantics** — I used each round's **start** (`start + interval * index`), mirroring `days-left.tsx`'s `currentRoundStart`. If the design intends the round's claim/withdraw moment (end of the deposit window), that's a one-line change.
2. **"Created on"** uses `effectiveCircleStartTime` (the circle's start) — the closest available on-chain value to a creation date.
3. I hand-rolled the horizontal scroller rather than reusing `src/components/card-carousel.tsx`, which is tightly coupled to the home-page stack list (`ICircleList`/`Stack`, paged grid) and isn't a fit here.

## Verification
- `pnpm lint` — clean (no new warnings/errors from these files).
- `tsc --noEmit` — passes (the full `next build` type-check gate is `tsc`; I ran it directly as the sandbox lacks RAM for a full `next build`).
- Pre-commit hook (prettier + `next lint --fix`) ran and passed on commit.
- ⚠️ I could **not** run `pnpm dev` to eyeball it in-browser in this environment — please give the Netlify deploy preview a look on a real stack to confirm the layout matches Figma (spacing, the current-turn highlight, and the mobile horizontal scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)