### PR TITLE
fix: allow self-custody EOA registration (stop forcing a Privy embedded wallet)

### DIFF
--- a/src/components/providers/index.tsx
+++ b/src/components/providers/index.tsx
@@ -40,7 +40,11 @@ const privyConfig = (isMobile: boolean): PrivyClientConfig => ({
   supportedChains: [_chain],
   embeddedWallets: {
     ethereum: {
-      createOnLogin: "all-users",
+      // Only provision a Privy embedded wallet for users who DON'T bring their
+      // own wallet (e.g. email/social sign-ins). Users who connect a
+      // self-custody EOA (MetaMask, Rabby, Coinbase Wallet, etc.) keep using
+      // that wallet instead of having a Privy wallet force-created for them.
+      createOnLogin: "users-without-wallets",
     },
   },
   walletConnectCloudProjectId: clientEnv.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,

--- a/src/lib/onboarding/supabase.ts
+++ b/src/lib/onboarding/supabase.ts
@@ -1,16 +1,31 @@
 import type { User, WalletWithMetadata } from "@privy-io/react-auth";
 
 export const onboardSupabaseUser = async (user: User) => {
-  const privayWallet = user.linkedAccounts.find(
-    (a) => a.type === "wallet" && a.walletClientType === "privy"
+  // Record the user's operative wallet. Prefer the Privy embedded wallet when
+  // one exists (email/social sign-ins), but fall back to the connected
+  // self-custody (external) wallet so EOA sign-ins (MetaMask, Rabby, etc.)
+  // still register with their own address instead of null.
+  const walletAccounts = user.linkedAccounts.filter(
+    (a): a is WalletWithMetadata => a.type === "wallet"
   );
+  const embeddedWallet = walletAccounts.find(
+    (a) => a.walletClientType === "privy"
+  );
+  const externalWallet = walletAccounts.find(
+    (a) => a.walletClientType !== "privy"
+  );
+  const walletAddress =
+    embeddedWallet?.address ??
+    externalWallet?.address ??
+    user.wallet?.address ??
+    null;
 
   const response = await fetch("/api/onboard", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       privyUserId: user.id,
-      walletAddress: (privayWallet as WalletWithMetadata)?.address ?? null, //  this shouldn't be null
+      walletAddress,
     }),
   });
 


### PR DESCRIPTION
## Problem

Reported by daopunk in #core-team: signing in with MetaMask still created a **Privy embedded wallet**, so BREAD ended up on an address the user doesn't control and has to transfer out of. There was no path to register/use a **self-custody EOA**.

## Root cause

`src/components/providers/index.tsx` set:
```ts
embeddedWallets: { ethereum: { createOnLogin: "all-users" } }
```
`"all-users"` provisions a Privy embedded wallet for **everyone** — even users who connect their own wallet. The external wallets were already offered in the login list (`metamask`, `coinbase_wallet`, `rainbow`, `wallet_connect`, `detected_ethereum_wallets`), but the embedded wallet was force-created on top.

## Changes

1. **`providers/index.tsx`** — `createOnLogin: "all-users"` → **`"users-without-wallets"`**. An embedded wallet is now only created for users who *don't* bring their own (email/social sign-ins). Self-custody EOA sign-ins operate on their own wallet.
2. **`lib/onboarding/supabase.ts`** — onboarding previously hard-coded `walletAddress` to the Privy embedded wallet (and the code even noted `// this shouldn't be null`). It now prefers the embedded wallet but **falls back to the connected external EOA** (`user.wallet?.address` as a final fallback), so self-custody users register with their real address instead of `null`.

## Notes / follow-ups (not blocking)
- Privy still handles **auth** (login-with-wallet issues the token bridged into Supabase) — this PR changes wallet *custody*, not the auth provider.
- Gas-sponsored txs (`useSponsoredTx`, via the Privy embedded wallet) won't apply to external-EOA users — they'll sign and pay gas with their own wallet, which is expected for self-custody. Worth a follow-up to confirm the deposit/claim UX reads cleanly for external wallets.

## Test plan
- [ ] Sign in with MetaMask/Rabby → **no** Privy embedded wallet is created; the connected EOA is the operative address.
- [ ] Supabase `users` row records the external EOA in `wallet_address` (not null).
- [ ] Sign in with email/social → embedded wallet still created as before.
- [ ] Deposit/claim flows work when signed in with an external EOA.

cc @Olaleye-Blessing — context from the thread; would appreciate a review since this touches the Privy ↔ Supabase onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)