### PR TITLE
fix(stacks): same-origin RPC proxy so VPN/DNS/CORS can't break reads

### DIFF
--- a/src/app/api/rpc/route.ts
+++ b/src/app/api/rpc/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from "next/server";
+
+// Same-origin JSON-RPC proxy.
+//
+// The browser talks to /api/rpc (first-party, same origin as the app that just
+// loaded) and this route forwards the JSON-RPC body to the upstream RPC
+// server-side. This keeps on-chain reads working for users whose VPN / DNS /
+// ad-blocker blocks, reroutes, or CORS-breaks the public RPC endpoint directly
+// (reported by a member on a VPN), and keeps the upstream URL off the client.
+//
+// Override the upstreams with GNOSIS_RPC_URL / SEPOLIA_RPC_URL (e.g. a private
+// Alchemy/Ankr endpoint) in the server environment.
+const UPSTREAM: Record<string, string> = {
+  "100": process.env.GNOSIS_RPC_URL || "https://rpc.gnosischain.com",
+  "11155111":
+    process.env.SEPOLIA_RPC_URL ||
+    "https://ethereum-sepolia-rpc.publicnode.com",
+};
+
+export async function POST(req: NextRequest) {
+  const chainId = req.nextUrl.searchParams.get("chainId") || "100";
+  const upstream = UPSTREAM[chainId];
+  if (!upstream) {
+    return new Response(
+      JSON.stringify({ error: `unsupported chainId ${chainId}` }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const body = await req.text();
+  try {
+    const res = await fetch(upstream, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "upstream RPC unreachable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/components/providers/web3.tsx
+++ b/src/components/providers/web3.tsx
@@ -60,6 +60,16 @@ const connectors = connectorsForWallets(
   }
 );
 
+// Route the primary chain's reads through the app's own /api/rpc proxy when an
+// app URL is configured, so VPN/DNS/CORS filtering of the public RPC can't
+// break on-chain reads (the browser only talks to our own origin). Needs an
+// ABSOLUTE base so it works during SSR prefetch too; falls back to a direct
+// http() transport when NEXT_PUBLIC_APP_URL is unset (behavior unchanged).
+const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+const gnosisTransport = appUrl
+  ? http(`${appUrl.replace(/\/$/, "")}/api/rpc?chainId=${gnosis.id}`)
+  : http();
+
 export const wagmiConfig = createConfig({
   connectors,
   // @ts-expect-error Correct
@@ -71,7 +81,7 @@ export const wagmiConfig = createConfig({
     return _chains;
   })(),
   transports: {
-    [gnosis.id]: http(),
+    [gnosis.id]: gnosisTransport,
     [foundryChain.id]: http(),
     [sepolia.id]: http(),
     // for lifi


### PR DESCRIPTION
## Problem
daopunk hit a **CORS / access-control** failure that only happened **on a VPN** (works with VPN off). CORS is enforced by the *upstream server*, so a VPN shouldn't normally trip it — the likely cause is the VPN's DNS/egress blocking or rerouting the **public RPC endpoint**, which the browser surfaces as a CORS/load failure.

## Fix
Route the primary chain's reads through a **first-party `/api/rpc` proxy**. The browser only ever talks to the app's own origin (which already loaded fine), and the server forwards the JSON-RPC to the upstream — so a client-side DNS/CORS/ad-block filter can't break reads. Bonus: the upstream RPC URL stays off the client.

- New `src/app/api/rpc/route.ts` — same-origin JSON-RPC proxy (gnosis + sepolia; override upstreams via `GNOSIS_RPC_URL` / `SEPOLIA_RPC_URL`).
- `web3.tsx` — the gnosis transport uses the proxy **only when `NEXT_PUBLIC_APP_URL` is set** (absolute base so SSR prefetch works too); otherwise it's a plain `http()` — **no behavior change if unconfigured**.

Only affects **reads/simulation** (the wagmi transport). Tx submission still goes through Privy/the connector, untouched.

## ⚠️ Needs confirmation
I inferred the public RPC as the blocked endpoint but couldn't see the exact domain in daopunk's screenshot. **@daopunk — what's the exact URL in the CORS error?** If it's Supabase, WalletConnect, or something else, I'll extend the same-origin approach to that endpoint. To activate this: set `NEXT_PUBLIC_APP_URL=https://stacks.bread.coop` (and optionally private `GNOSIS_RPC_URL`) in the deploy env.

## Test plan
- [ ] With `NEXT_PUBLIC_APP_URL` set, reads flow through `/api/rpc` (Network tab shows same-origin RPC calls); app works on a VPN.
- [ ] Unset `NEXT_PUBLIC_APP_URL` → behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)