### PR TITLE
feat: allow funding stacks wallet with BREAD or xDAI

### DIFF
--- a/src/components/modal/modals/fund-wallet/fund-with-connected-wallet-modal-amount.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-with-connected-wallet-modal-amount.tsx
@@ -2,31 +2,17 @@
 
 import { Label } from "@/components/label";
 import NumericInput from "@/components/numeric-input";
-import { useEffect, useState } from "react";
+import { SubmitEventHandler, useState } from "react";
 import { ModalContainer, ModalHeader } from "../../components";
 import LocalButton from "@/components/button";
-import { Body, formatBalance, useConnectedUser } from "@breadcoop/ui";
-import { useWaitForTxReceipt } from "@/hooks/use-wait-for-tx-receipt";
-import {
-  useBalance,
-  useChainId,
-  useSendTransaction,
-  useSwitchChain,
-} from "wagmi";
-import { useSimulateAndSponsorTx } from "@/hooks/use-simulate-and-sponsor-tx";
+import { Body, formatBalance, Logo, useConnectedUser } from "@breadcoop/ui";
 import { useModal } from "../../context";
+import { formatEther, parseEther } from "viem";
 import {
-  Address,
-  createWalletClient,
-  custom,
-  formatEther,
-  Hex,
-  parseEther,
-} from "viem";
-import { getDefaultChainDetail } from "@/utils/chain";
-import { clientEnv } from "@/lib/env";
-import { BREAD_TOKEN_ADDRESS } from "@/lib/constants";
-import { breadAbi } from "@/lib/abis/bread-abi";
+  FUNDING_TOKENS,
+  FundingToken,
+  useFundWithConnectedWallet,
+} from "@/hooks/use-fund-with-connected-wallet";
 
 export interface FundWithConnectedWalletModalAmountModalState {
   type: "FUND_WITH_CONNECTED_WALLET_MODAL_AMOUNT";
@@ -37,138 +23,57 @@ interface FundWithConnectedWalletModalAmountProps {
   modalState: FundWithConnectedWalletModalAmountModalState;
 }
 
+const XDAI_GAS_BUFFER = parseEther("0.001");
+
+const TokenIcon = ({ token }: { token: FundingToken }) =>
+  token === "BREAD" ? (
+    <Logo size={20} />
+  ) : (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src="/gnosis_icon.svg" alt="" className="w-5 h-5" />
+  );
+
 const FundWithConnectedWalletModalAmount = ({
   modalState,
 }: FundWithConnectedWalletModalAmountProps) => {
-  const currentChainId = useChainId();
-  const { switchChainAsync } = useSwitchChain();
   const { user } = useConnectedUser();
-  const { waitForTxReceipt } = useWaitForTxReceipt();
-  const { sendTransactionAsync } = useSendTransaction();
   const { setModal } = useModal();
-  const { simulateAndSponsorTx } = useSimulateAndSponsorTx();
   const [amount, setAmount] = useState("0");
-  const [externalAccount, setExternalAccount] = useState<Address | undefined>();
+  const [token, setToken] = useState<FundingToken>("xDAI");
+  const { xDaiBalance, breadBalance, fundWallet } =
+    useFundWithConnectedWallet();
 
-  const xDaiBalance = useBalance({
-    address: externalAccount,
-    chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
-    query: {
-      enabled: Boolean(externalAccount),
-    },
-  });
+  const tokenBalance = token === "BREAD" ? breadBalance : xDaiBalance;
 
-  useEffect(() => {
-    if (!window.ethereum) return;
+  const formattedBalance = +formatEther(tokenBalance.data?.value || BigInt(0));
 
-    const client = createWalletClient({
-      chain: getDefaultChainDetail(),
-      transport: custom(window.ethereum),
-    });
+  const parsedAmount = (() => {
+    try {
+      return parseEther(amount);
+    } catch {
+      return null;
+    }
+  })();
 
-    client.requestAddresses().then(([account]) => {
-      if (account) setExternalAccount(account);
-    });
-  }, []);
+  const maxAmount = (() => {
+    if (!tokenBalance.data) return BigInt(0);
+    if (token === "BREAD") return tokenBalance.data.value;
 
-  const formattedBalance = +formatEther(xDaiBalance.data?.value || BigInt(0));
+    const max = tokenBalance.data.value - XDAI_GAS_BUFFER;
+    return max > BigInt(0) ? max : BigInt(0);
+  })();
 
   const disabled =
-    !amount ||
-    Number(amount) <= 0 ||
-    (xDaiBalance.data ? Number(amount) > formattedBalance : false);
+    parsedAmount === null ||
+    parsedAmount <= BigInt(0) ||
+    (tokenBalance.data ? parsedAmount > tokenBalance.data.value : false);
 
-  const fundWallet = async () => {
-    if (
-      !(user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN") ||
-      disabled
-    )
-      return;
+  const handleSubmit: SubmitEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
 
-    const formattedAmount = parseEther(amount);
+    if (disabled) return;
 
-    try {
-      setModal({ type: "WALLET_FUNDING_STATUS", status: "loading" });
-
-      let xDaiDepositHash: Hex;
-
-      if (modalState.wallet) {
-        if (currentChainId !== clientEnv.NEXT_PUBLIC_CHAIN_ID) {
-          await switchChainAsync({ chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID });
-        }
-
-        xDaiDepositHash = await sendTransactionAsync({
-          to: user.address,
-          value: formattedAmount,
-          chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
-        });
-      } else {
-        // this won't trigger
-        if (!window.ethereum) return;
-
-        const walletClient = createWalletClient({
-          chain: getDefaultChainDetail(),
-          transport: custom(window.ethereum),
-        });
-
-        const [account] = await walletClient.requestAddresses();
-
-        if (!account) {
-          console.warn(
-            "[FundWithConnectedWalletContent]: User rejected wallet connection"
-          );
-          return;
-        }
-
-        const currentChainId = await walletClient.getChainId();
-
-        if (currentChainId !== clientEnv.NEXT_PUBLIC_CHAIN_ID) {
-          await walletClient.switchChain({
-            id: clientEnv.NEXT_PUBLIC_CHAIN_ID,
-          });
-        }
-
-        xDaiDepositHash = await walletClient.sendTransaction({
-          account,
-          to: user.address as Address,
-          value: formattedAmount,
-          chain: getDefaultChainDetail(),
-        });
-      }
-
-      await waitForTxReceipt(xDaiDepositHash);
-
-      await simulateAndSponsorTx({
-        address: BREAD_TOKEN_ADDRESS,
-        abi: breadAbi,
-        functionName: "mint",
-        args: [user.address],
-        value: formattedAmount,
-        options: {
-          uiOptions: {
-            showWalletUIs: false,
-          },
-        },
-      });
-
-      setModal({
-        type: "WALLET_FUNDING_STATUS",
-        status: "success",
-        breadAmount: amount,
-      });
-    } catch (error) {
-      console.error(
-        "[FundWithConnectedWalletContent]: Transaction failed",
-        error
-      );
-      setModal({
-        type: "WALLET_FUNDING_STATUS",
-        status: "error",
-        onRetry: async () => {
-          setModal({ type: "FUND_WALLET", address: user.address });
-        },
-      });
-    }
+    await fundWallet({ token, amount, wallet: modalState.wallet });
   };
 
   return (
@@ -190,7 +95,25 @@ const FundWithConnectedWalletModalAmount = ({
           Back
         </button>
       </div>
-      <form onSubmit={fundWallet}>
+      <form onSubmit={handleSubmit}>
+        <Label>Fund with</Label>
+        <div className="flex gap-2 mb-4">
+          {FUNDING_TOKENS.map((fundingToken) => (
+            <button
+              key={fundingToken}
+              type="button"
+              onClick={() => setToken(fundingToken)}
+              className={`flex-1 flex items-center justify-center gap-2 border py-2 font-bold transition-colors cursor-pointer ${
+                token === fundingToken
+                  ? "border-primary-blue text-primary-blue bg-paper-1"
+                  : "border-paper-2 text-surface-grey"
+              }`}
+            >
+              <TokenIcon token={fundingToken} />
+              {fundingToken}
+            </button>
+          ))}
+        </div>
         <Label htmlFor="depositAmount">Amount</Label>
         <div className="relative">
           <NumericInput
@@ -202,18 +125,19 @@ const FundWithConnectedWalletModalAmount = ({
             allowDecimal
           />
           <div className="absolute top-1/2 -translate-y-1/2 right-1 p-1 flex items-center justify-end gap-2.5">
-            <Body bold className="bg-paper-main">
-              XDAI
+            <Body bold className="bg-paper-main flex items-center gap-1.5">
+              <TokenIcon token={token} />
+              {token.toUpperCase()}
             </Body>
             <button
               onClick={() => {
-                if (xDaiBalance.isFetching) return;
+                if (tokenBalance.isLoading) return;
 
-                setAmount(`${formattedBalance}`);
+                setAmount(formatEther(maxAmount));
               }}
-              disabled={xDaiBalance.isFetching}
+              disabled={tokenBalance.isLoading}
               type="button"
-              className={`inline-block font-bold max-w-max text-sm transition-colors ${xDaiBalance.data ? "text-primary-blue cursor-pointer" : "text-surface-grey cursor-not-allowed"}`}
+              className={`inline-block font-bold max-w-max text-sm transition-colors ${tokenBalance.data ? "text-primary-blue cursor-pointer" : "text-surface-grey cursor-not-allowed"}`}
             >
               Max.
             </button>
@@ -221,7 +145,7 @@ const FundWithConnectedWalletModalAmount = ({
         </div>
         <Body className="max-w-max ml-auto mt-1 text-sm text-surface-grey">
           Balance:{" "}
-          {xDaiBalance.isFetching
+          {tokenBalance.isLoading
             ? "Loading..."
             : formatBalance(formattedBalance)}
         </Body>

--- a/src/hooks/use-fund-with-connected-wallet.ts
+++ b/src/hooks/use-fund-with-connected-wallet.ts
@@ -1,0 +1,192 @@
+import { useEffect, useState } from "react";
+import {
+  useBalance,
+  useChainId,
+  useSendTransaction,
+  useSwitchChain,
+  useWriteContract,
+} from "wagmi";
+import {
+  Address,
+  createWalletClient,
+  custom,
+  erc20Abi,
+  Hex,
+  parseEther,
+} from "viem";
+import { useConnectedUser } from "@breadcoop/ui";
+import { useModal } from "@/components/modal/context";
+import { useWaitForTxReceipt } from "@/hooks/use-wait-for-tx-receipt";
+import { useSimulateAndSponsorTx } from "@/hooks/use-simulate-and-sponsor-tx";
+import { getDefaultChainDetail } from "@/utils/chain";
+import { clientEnv } from "@/lib/env";
+import { BREAD_TOKEN_ADDRESS } from "@/lib/constants";
+import { breadAbi } from "@/lib/abis/bread-abi";
+
+export const FUNDING_TOKENS = ["BREAD", "xDAI"] as const;
+
+export type FundingToken = (typeof FUNDING_TOKENS)[number];
+
+interface FundWalletParams {
+  token: FundingToken;
+  amount: string;
+  /** Connected wallet type from the modal state; funds via wagmi when set */
+  wallet?: string;
+}
+
+export const useFundWithConnectedWallet = () => {
+  const currentChainId = useChainId();
+  const { switchChainAsync } = useSwitchChain();
+  const { user } = useConnectedUser();
+  const { waitForTxReceipt } = useWaitForTxReceipt();
+  const { sendTransactionAsync } = useSendTransaction();
+  const { writeContractAsync } = useWriteContract();
+  const { setModal } = useModal();
+  const { simulateAndSponsorTx } = useSimulateAndSponsorTx();
+  const [externalAccount, setExternalAccount] = useState<Address | undefined>();
+
+  const xDaiBalance = useBalance({
+    address: externalAccount,
+    chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
+    query: {
+      enabled: Boolean(externalAccount),
+    },
+  });
+
+  const breadBalance = useBalance({
+    address: externalAccount,
+    token: BREAD_TOKEN_ADDRESS,
+    chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
+    query: {
+      enabled: Boolean(externalAccount),
+    },
+  });
+
+  useEffect(() => {
+    if (!window.ethereum) return;
+
+    const client = createWalletClient({
+      chain: getDefaultChainDetail(),
+      transport: custom(window.ethereum),
+    });
+
+    client.getAddresses().then(([account]) => {
+      if (account) setExternalAccount(account);
+    });
+  }, []);
+
+  const fundWallet = async ({ token, amount, wallet }: FundWalletParams) => {
+    if (!(user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN"))
+      return;
+
+    try {
+      setModal({ type: "WALLET_FUNDING_STATUS", status: "loading" });
+
+      const formattedAmount = parseEther(amount);
+
+      let depositHash: Hex;
+
+      if (wallet) {
+        if (currentChainId !== clientEnv.NEXT_PUBLIC_CHAIN_ID) {
+          await switchChainAsync({ chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID });
+        }
+
+        if (token === "BREAD") {
+          depositHash = await writeContractAsync({
+            address: BREAD_TOKEN_ADDRESS,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [user.address as Address, formattedAmount],
+            chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
+          });
+        } else {
+          depositHash = await sendTransactionAsync({
+            to: user.address,
+            value: formattedAmount,
+            chainId: clientEnv.NEXT_PUBLIC_CHAIN_ID,
+          });
+        }
+      } else {
+        // this won't trigger
+        if (!window.ethereum) return;
+
+        const walletClient = createWalletClient({
+          chain: getDefaultChainDetail(),
+          transport: custom(window.ethereum),
+        });
+
+        const [account] = await walletClient.requestAddresses();
+
+        if (!account) {
+          console.warn(
+            "[FundWithConnectedWalletContent]: User rejected wallet connection"
+          );
+          return;
+        }
+
+        const currentChainId = await walletClient.getChainId();
+
+        if (currentChainId !== clientEnv.NEXT_PUBLIC_CHAIN_ID) {
+          await walletClient.switchChain({
+            id: clientEnv.NEXT_PUBLIC_CHAIN_ID,
+          });
+        }
+
+        if (token === "BREAD") {
+          depositHash = await walletClient.writeContract({
+            account,
+            address: BREAD_TOKEN_ADDRESS,
+            abi: erc20Abi,
+            functionName: "transfer",
+            args: [user.address as Address, formattedAmount],
+            chain: getDefaultChainDetail(),
+          });
+        } else {
+          depositHash = await walletClient.sendTransaction({
+            account,
+            to: user.address as Address,
+            value: formattedAmount,
+            chain: getDefaultChainDetail(),
+          });
+        }
+      }
+
+      await waitForTxReceipt(depositHash);
+
+      if (token === "xDAI") {
+        await simulateAndSponsorTx({
+          address: BREAD_TOKEN_ADDRESS,
+          abi: breadAbi,
+          functionName: "mint",
+          args: [user.address],
+          value: formattedAmount,
+          options: {
+            uiOptions: {
+              showWalletUIs: false,
+            },
+          },
+        });
+      }
+
+      setModal({
+        type: "WALLET_FUNDING_STATUS",
+        status: "success",
+        breadAmount: amount,
+      });
+    } catch (error) {
+      console.error(
+        "[FundWithConnectedWalletContent]: Transaction failed",
+        error
+      );
+      setModal({
+        type: "WALLET_FUNDING_STATUS",
+        status: "error",
+        onRetry: async () => {
+          setModal({ type: "FUND_WALLET", address: user.address });
+        },
+      });
+    }
+  };
+
+  return { xDaiBalance, breadBalance, fundWallet };
+};


### PR DESCRIPTION
Add a token selector to the funding amount modal so users can fund with either token. BREAD transfers directly via ERC-20 transfer; xDAI keeps the send-then-mint flow. Balances for both tokens are prefetched, the account is read silently (eth_accounts) instead of prompting on open, amount validation compares bigints exactly, and "Max." reserves a gas buffer for native xDAI. Transaction logic is extracted into a useFundWithConnectedWallet hook.