### PR TITLE
feat: configure feature flags via NEXT_PUBLIC_FEATURES env var

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -47,3 +47,8 @@ NEXT_PUBLIC_SEPOLIA_RPC_URL=
 # Sepolia embedded-wallet auto-funding
 SEPOLIA_RPC_URL=
 AUTOMATIC_FUNDING_PRIVATE_KEY=
+
+# Feature gating (JSON, per deployment). Feature key absent or enabled=false -> hidden;
+# addresses present -> only those wallets see it. Local always shows every feature.
+# e.g. {"automaticClaim":{"enabled":true,"addresses":["0x6532665Cde5Cc99bbABf4Be4bbF178bD13CC849d"]}}
+NEXT_PUBLIC_FEATURES=

--- a/src/components/feature-gate.tsx
+++ b/src/components/feature-gate.tsx
@@ -1,11 +1,28 @@
 "use client";
 
-import { type Feature, isFeatureEnabled } from "@/lib/features";
+import { type Feature, isFeatureVisible } from "@/lib/features";
+import { useConnectedUser } from "@breadcoop/ui";
 import type { ComponentType, ReactNode } from "react";
 
 /**
- * Renders `children` only when `feature` is enabled in the current
- * environment, otherwise renders `fallback` (nothing by default).
+ * True when `feature` is enabled for this deployment and, if the feature's
+ * config lists addresses, the connected wallet is one of them. See
+ * NEXT_PUBLIC_FEATURES in @/lib/features.
+ */
+function useFeatureVisible(feature: Feature) {
+  const { user } = useConnectedUser();
+
+  const connectedAddress =
+    user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN"
+      ? user.address
+      : undefined;
+
+  return isFeatureVisible(feature, connectedAddress);
+}
+
+/**
+ * Renders `children` only when `feature` is visible to the current user,
+ * otherwise renders `fallback` (nothing by default).
  */
 export function FeatureGate({
   feature,
@@ -16,19 +33,19 @@ export function FeatureGate({
   children: ReactNode;
   fallback?: ReactNode;
 }) {
-  return <>{isFeatureEnabled(feature) ? children : fallback}</>;
+  return <>{useFeatureVisible(feature) ? children : fallback}</>;
 }
 
 /**
  * HOC variant of {@link FeatureGate}: wraps a component so it only renders
- * when `feature` is enabled in the current environment.
+ * when `feature` is visible to the current user.
  */
 export function withFeatureGate<P extends object>(
   feature: Feature,
   Component: ComponentType<P>
 ) {
   function FeatureGated(props: P) {
-    return isFeatureEnabled(feature) ? <Component {...props} /> : null;
+    return useFeatureVisible(feature) ? <Component {...props} /> : null;
   }
 
   FeatureGated.displayName = `withFeatureGate(${

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,6 +14,14 @@ const depositIntervalSchema = z
   )
   .min(2, "At least two deposit intervals are required");
 
+const featuresSchema = z.record(
+  z.string(),
+  z.object({
+    enabled: z.boolean(),
+    addresses: z.array(z.string().regex(/^0x[a-fA-F0-9]{40}$/)).optional(),
+  })
+);
+
 const envSchema = z.object({
   NEXT_PUBLIC_CHAIN_ID: z.coerce.number(),
   NEXT_PUBLIC_SAVING_CIRCLES_CONTRACT_ADDRESS: z.string(),
@@ -45,6 +53,22 @@ const envSchema = z.object({
       }
     })
     .pipe(depositIntervalSchema),
+  NEXT_PUBLIC_FEATURES: z
+    .string()
+    .optional()
+    .default("{}")
+    .transform((val, ctx) => {
+      try {
+        return JSON.parse(val) as Record<string, unknown>;
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "NEXT_PUBLIC_FEATURES must be valid JSON",
+        });
+        return z.NEVER;
+      }
+    })
+    .pipe(featuresSchema),
 });
 
 const parsedSchema = envSchema.safeParse({
@@ -69,6 +93,7 @@ const parsedSchema = envSchema.safeParse({
   NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   NEXT_PUBLIC_DEPOSIT_INTERVALS: process.env.NEXT_PUBLIC_DEPOSIT_INTERVALS,
+  NEXT_PUBLIC_FEATURES: process.env.NEXT_PUBLIC_FEATURES,
 });
 
 if (!parsedSchema.success) {

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,27 +1,37 @@
 import { clientEnv } from "./env";
 
-type Environment = (typeof clientEnv)["NEXT_PUBLIC_NODE_ENV"];
-
-// Local always renders every feature, so it never needs to be listed per
-// feature — only the non-local environments are configured below.
-type GatedEnvironment = Exclude<Environment, "local">;
-
 /**
- * Maps each feature to the environments it is allowed to render in. Local is
- * implicitly always enabled, so list only "development" / "demo" / "production".
- * Add a feature here, then gate it with <FeatureGate> or withFeatureGate
- * (see @/components/feature-gate).
+ * All gateable features. Add a feature here, configure it per deployment via
+ * the NEXT_PUBLIC_FEATURES env var, then gate it with <FeatureGate> or
+ * withFeatureGate (see @/components/feature-gate).
+ *
+ * NEXT_PUBLIC_FEATURES is a JSON object keyed by feature name:
+ *
+ *   {"automaticClaim":{"enabled":true,"addresses":["0x6532..."]}}
+ *
+ * - feature key absent or `enabled: false` -> hidden in that deployment
+ * - `addresses` present -> only those connected wallets see the feature
+ * - `addresses` absent or empty -> every user sees it
+ * - local always renders every feature regardless of config
  */
-export const FEATURE_ENVIRONMENTS = {
-  automaticClaim: ["development"],
-} satisfies Record<string, GatedEnvironment[]>;
+export const FEATURES = ["automaticClaim"] as const;
 
-export type Feature = keyof typeof FEATURE_ENVIRONMENTS;
+export type Feature = (typeof FEATURES)[number];
 
-export function isFeatureEnabled(feature: Feature): boolean {
-  const env = clientEnv.NEXT_PUBLIC_NODE_ENV;
-  if (env === "local") return true;
+export function isFeatureVisible(
+  feature: Feature,
+  connectedAddress?: string
+): boolean {
+  if (clientEnv.NEXT_PUBLIC_NODE_ENV === "local") return true;
 
-  const allowed: readonly GatedEnvironment[] = FEATURE_ENVIRONMENTS[feature];
-  return allowed.includes(env);
+  const config = clientEnv.NEXT_PUBLIC_FEATURES[feature];
+  if (!config?.enabled) return false;
+  if (!config.addresses || config.addresses.length === 0) return true;
+
+  if (!connectedAddress) return false;
+
+  const normalized = connectedAddress.toLowerCase();
+  return config.addresses.some(
+    (address) => address.toLowerCase() === normalized
+  );
 }


### PR DESCRIPTION
Replace the code-level FEATURE_ENVIRONMENTS map with per-deployment JSON config so features can be toggled per Netlify context without a code change:

  NEXT_PUBLIC_FEATURES='{"automaticClaim":{"enabled":true,"addresses":["0x..."]}}'

- feature key absent or enabled=false hides the feature
- addresses (validated 0x addresses) restrict it to specific connected wallets, compared case-insensitively
- local always renders every feature
- var is optional (defaults to {}); malformed JSON fails the build

The Feature union stays in code so gate call sites remain type-checked. FeatureGate/withFeatureGate keep their existing API.

Deployments that previously relied on FEATURE_ENVIRONMENTS (automatic claim on development) must now set NEXT_PUBLIC_FEATURES and redeploy.