### PR TITLE
feat(username): set a display name shown instead of your address

### DIFF
--- a/src/app/api/user/username/route.ts
+++ b/src/app/api/user/username/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getAddress, isAddress } from "viem";
+import { z } from "zod";
+import { serverEnv } from "@/lib/envs/server";
+import { createErrorResponse } from "../../utils";
+
+// Service-role client (bypasses RLS) — same pattern as /api/onboard and /api/user.
+const supabaseAdmin = createClient(
+  serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+  serverEnv.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// 3–20 chars: letters, numbers, underscore. Case is preserved for display, but
+// uniqueness is enforced case-insensitively (see PATCH).
+const usernameSchema = z
+  .string()
+  .trim()
+  .min(3, "Username must be at least 3 characters")
+  .max(20, "Username must be at most 20 characters")
+  .regex(/^[A-Za-z0-9_]+$/, "Use only letters, numbers, and underscores");
+
+const setBodySchema = z.object({
+  privyUserId: z.string().min(1),
+  username: usernameSchema,
+});
+
+const MAX_ADDRESSES = 100;
+
+/**
+ * PATCH — set/update the caller's display username.
+ * Body: { privyUserId, username }. Trust model matches the other routes
+ * (privyUserId comes from a logged-in Privy session; see /api/onboard).
+ */
+export async function PATCH(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return createErrorResponse("Invalid JSON in request body");
+  }
+
+  const parsed = setBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return createErrorResponse(
+      parsed.error.issues[0]?.message ?? "Invalid request body"
+    );
+  }
+  const { privyUserId, username } = parsed.data;
+
+  const { data: user, error: userErr } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("privy_user_id", privyUserId)
+    .single();
+  if (userErr || !user) return createErrorResponse("User not found", 404);
+
+  // Case-insensitive uniqueness. `ilike` treats `_` as a wildcard, so it only
+  // narrows to a superset — we confirm an exact (lowercased) clash in JS.
+  const { data: candidates, error: takenErr } = await supabaseAdmin
+    .from("profiles")
+    .select("user_id, username")
+    .ilike("username", username);
+  if (takenErr) {
+    console.error("Username uniqueness check failed:", takenErr);
+    return createErrorResponse("Failed to check username", 500);
+  }
+  const clash = (candidates ?? []).find(
+    (c) =>
+      c.user_id !== user.id &&
+      c.username?.toLowerCase() === username.toLowerCase()
+  );
+  if (clash) return createErrorResponse("That username is already taken", 409);
+
+  const { error: upErr } = await supabaseAdmin.from("profiles").upsert(
+    { user_id: user.id, username, updated_at: new Date().toISOString() },
+    { onConflict: "user_id" }
+  );
+  if (upErr) {
+    console.error("Failed to save username:", upErr);
+    return createErrorResponse("Failed to save username", 500);
+  }
+
+  return NextResponse.json({ success: true, username });
+}
+
+/**
+ * GET — resolve usernames for one or more addresses.
+ * Query: ?addresses=0x..,0x..  (or ?address=0x..)
+ * Returns: { usernames: { [lowercasedAddress]: username } } (only set ones).
+ */
+export async function GET(req: NextRequest) {
+  const raw =
+    req.nextUrl.searchParams.get("addresses") ??
+    req.nextUrl.searchParams.get("address");
+  if (!raw) return createErrorResponse("addresses query param is required");
+
+  const requested = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, MAX_ADDRESSES);
+  const valid = requested.filter((a) => isAddress(a));
+  if (valid.length === 0) return NextResponse.json({ usernames: {} });
+
+  // Stored casing is unknown (Privy gives checksummed), so match both variants
+  // and key the result by lowercased address.
+  const variants = Array.from(
+    new Set(valid.flatMap((a) => [getAddress(a), a.toLowerCase()]))
+  );
+
+  const { data: users, error: usersErr } = await supabaseAdmin
+    .from("users")
+    .select("id, wallet_address")
+    .in("wallet_address", variants);
+  if (usersErr) {
+    console.error("Failed to resolve users:", usersErr);
+    return createErrorResponse("Failed to resolve users", 500);
+  }
+
+  const idToAddress = new Map<string, string>();
+  for (const u of users ?? []) {
+    if (u.wallet_address) idToAddress.set(u.id, u.wallet_address.toLowerCase());
+  }
+
+  const usernames: Record<string, string> = {};
+  const ids = [...idToAddress.keys()];
+  if (ids.length > 0) {
+    const { data: profiles, error: profErr } = await supabaseAdmin
+      .from("profiles")
+      .select("user_id, username")
+      .in("user_id", ids);
+    if (profErr) {
+      console.error("Failed to resolve usernames:", profErr);
+      return createErrorResponse("Failed to resolve usernames", 500);
+    }
+    for (const p of profiles ?? []) {
+      const addr = idToAddress.get(p.user_id);
+      if (addr && p.username) usernames[addr] = p.username;
+    }
+  }
+
+  return NextResponse.json({ usernames });
+}

--- a/src/app/my-account/_components/account-content.tsx
+++ b/src/app/my-account/_components/account-content.tsx
@@ -3,6 +3,7 @@
 import { Body, useConnectedUser } from "@breadcoop/ui";
 import SolidarityFundSection from "./solidarity-fund-section";
 import StacksOverview from "./stacks-overview";
+import { UsernameSetting } from "./username-setting";
 
 export const AccountContent = () => {
   const { user } = useConnectedUser();
@@ -19,6 +20,7 @@ export const AccountContent = () => {
 
   return (
     <>
+      <UsernameSetting address={user.address} />
       <StacksOverview address={user.address} />
       <SolidarityFundSection />
     </>

--- a/src/app/my-account/_components/username-setting.tsx
+++ b/src/app/my-account/_components/username-setting.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { Body } from "@breadcoop/ui";
+import type { Address } from "viem";
+import Button from "@/components/button";
+import Input, { InputDescription } from "@/components/input";
+import { useUsername } from "@/hooks/use-usernames";
+
+/**
+ * Lets the connected user set a display username (stored in Supabase). Once set,
+ * the app shows the name instead of the wallet address in member lists.
+ */
+export function UsernameSetting({ address }: { address: Address }) {
+  const { user } = usePrivy();
+  const queryClient = useQueryClient();
+  const { username: current } = useUsername(address);
+
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    kind: "ok" | "error";
+    text: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (current) setValue(current);
+  }, [current]);
+
+  const onSave = async () => {
+    if (!user?.id) {
+      setMessage({ kind: "error", text: "Please sign in first." });
+      return;
+    }
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/user/username", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ privyUserId: user.id, username: value.trim() }),
+      });
+      const json = (await res.json()) as { error?: string; username?: string };
+      if (!res.ok) {
+        setMessage({ kind: "error", text: json.error ?? "Failed to save." });
+        return;
+      }
+      setMessage({ kind: "ok", text: "Username saved." });
+      queryClient.invalidateQueries({ queryKey: ["usernames"] });
+    } catch {
+      setMessage({ kind: "error", text: "Something went wrong. Try again." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const unchanged = value.trim() === (current ?? "");
+
+  return (
+    <section className="flex flex-col gap-3">
+      <Body bold className="text-lg">
+        Display name
+      </Body>
+      <InputDescription desc="Set a username so others see a name instead of your wallet address." />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="e.g. josh"
+          maxLength={20}
+          aria-label="Username"
+          className="flex-1"
+        />
+        <Button onClick={onSave} disabled={saving || unchanged || value.trim().length < 3}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+      {message && (
+        <Body
+          className={
+            message.kind === "ok" ? "text-system-success" : "text-system-warning"
+          }
+        >
+          {message.text}
+        </Body>
+      )}
+    </section>
+  );
+}
+
+export default UsernameSetting;

--- a/src/app/stacks/[id]/_components/members-info.tsx
+++ b/src/app/stacks/[id]/_components/members-info.tsx
@@ -13,6 +13,7 @@ import { useGetCircleCreated } from "@/hooks/use-get-cricle-created";
 import { useGetLastDeposit } from "@/hooks/use-get-last-deposit";
 import { useInviteRedeemed } from "@/hooks/use-invite-redeemed";
 import { usePreferredEnsName } from "@/hooks/use-preferred-ens-name";
+import { useUsername } from "@/hooks/use-usernames";
 import { useUserCircleData } from "@/hooks/use-user-circle-data";
 import { useFundsDeposited } from "@/hooks/use-funds-deposited";
 import { ICircleStatus } from "@/interfaces/circle";
@@ -252,11 +253,16 @@ function MemberInfoContent({
 }
 
 function MemberEnsName({ address }: { address: Address }) {
+  const { username } = useUsername(address);
   const { ensName, isLoading } = usePreferredEnsName({ address });
+
+  // Prefer a user-set username, then ENS, then the raw address. Show the
+  // username immediately even while the ENS lookup is still in flight.
+  const label = username || ensName || address;
 
   return (
     <span className="inline-flex items-center justify-start">
-      {isLoading ? "Loading..." : ensName || address}
+      {isLoading && !username ? "Loading..." : label}
     </span>
   );
 }

--- a/src/hooks/use-usernames.ts
+++ b/src/hooks/use-usernames.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Address } from "viem";
+
+type UsernameMap = Record<string, string>;
+
+async function fetchUsernames(addresses: string[]): Promise<UsernameMap> {
+  if (addresses.length === 0) return {};
+  const res = await fetch(
+    `/api/user/username?addresses=${encodeURIComponent(addresses.join(","))}`
+  );
+  if (!res.ok) return {};
+  const json = (await res.json()) as { usernames?: UsernameMap };
+  return json.usernames ?? {};
+}
+
+/**
+ * Resolve Supabase display usernames for a set of addresses. Returns a map
+ * keyed by lowercased address; addresses without a username are simply absent.
+ */
+export function useUsernames(addresses: (Address | undefined)[]) {
+  const list = Array.from(
+    new Set(
+      addresses
+        .filter((a): a is Address => Boolean(a))
+        .map((a) => a.toLowerCase())
+    )
+  ).sort();
+
+  const query = useQuery({
+    queryKey: ["usernames", list],
+    queryFn: () => fetchUsernames(list),
+    enabled: list.length > 0,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  return { usernames: query.data ?? {}, isLoading: query.isLoading };
+}
+
+/** Single-address convenience wrapper around {@link useUsernames}. */
+export function useUsername(address?: Address) {
+  const { usernames, isLoading } = useUsernames(address ? [address] : []);
+  return {
+    username: address ? usernames[address.toLowerCase()] : undefined,
+    isLoading,
+  };
+}


### PR DESCRIPTION
Implements Josh's request — *"let users set a username so ppl see names rather than addresses"* — the simple Supabase way (no ENS/onchain). The `profiles.username` column **already exists**, so no migration is needed.

## What's included
**Backend — `src/app/api/user/username/route.ts`** (service-role client, same trust model as `/api/onboard` & `/api/user`):
- `PATCH { privyUserId, username }` — validates (3–20 chars, `[A-Za-z0-9_]`), enforces **case-insensitive uniqueness**, upserts `profiles.username`.
- `GET ?addresses=0x..,0x..` — returns `{ usernames: { [lowercasedAddress]: name } }` for the set names. Matches both checksummed + lowercase stored casing.

**Frontend**
- `src/hooks/use-usernames.ts` — `useUsernames(addresses)` / `useUsername(address)` (react-query) to resolve names by address.
- `MemberEnsName` (stack member list) now renders **username → ENS → short address**, so names show up wherever members are listed.
- **My Account** gets a *"Display name"* setting to set/update your username (uses the local `Input`/`Button`, prefilled with your current name, live validation + save feedback, invalidates the username cache on save).

## Notes / follow-ups
- **Auth**: like the existing routes, the write trusts `privyUserId` from a logged-in Privy session (no server token verification anywhere in this app yet). Impersonation would require knowing another user's non-public `privyUserId`. If you want it airtight later, verify the Privy access token server-side (`@privy-io/server-auth`) — happy to do that as a follow-up.
- No test setup exists in the repo, so no tests added (kept consistent).
- Uniqueness is enforced in the route; a DB unique index on `lower(username)` would be a nice belt-and-suspenders add in the Supabase dashboard.

## Risk
Low — one additive API route, one hook, a display tweak, and a self-contained account setting. No contract/wagmi/deploy changes.