### PR TITLE
fix(nav): selected menu item changes color only, not weight

### DIFF
--- a/src/components/Navbar/nav-links.tsx
+++ b/src/components/Navbar/nav-links.tsx
@@ -25,7 +25,7 @@ const NavLinks = () => {
             aria-current={isActive ? "page" : undefined}
             className={cn(
               "text-body transition-colors hover:text-primary-blue",
-              isActive && "font-bold text-primary-blue"
+              isActive && "text-primary-blue"
             )}
           >
             {label}


### PR DESCRIPTION
## What & why

The selected navbar item was rendered **bold**, widening the text and shifting the nav layout when navigating between pages. Selected/hover should differ from default by **color only**.

Closes #141

## Change

`src/components/Navbar/nav-links.tsx` — active state `font-bold text-primary-blue` → `text-primary-blue` (color only). Hover was already color-only; `aria-current="page"` unchanged.

## Verification
- `tsc` + `eslint` clean.
- On the Netlify preview: hover items and switch between `/` and `/new` — the selected item changes color only, with no width/layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
