### PR TITLE
fix(account): standard press micro-interaction for Deposit/Withdraw buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:push:prod": "dotenv -e .env.local -- sh -c 'supabase db push --db-url \"$SUPABASE_DB_URL_PROD\"'"
   },
   "dependencies": {
-    "@breadcoop/ui": "^2.0.1",
+    "@breadcoop/ui": "2.0.2",
     "@duneanalytics/client-sdk": "^0.2.5",
     "@hookform/resolvers": "^5.2.2",
     "@lifi/sdk": "^3.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ settings:
 overrides:
   "@noble/curves": ">=1.9.0"
   semver: ">=6.3.2"
-  "@breadcoop/ui": 2.0.1
+  "@breadcoop/ui": 2.0.2
 
 importers:
   .:
     dependencies:
       "@breadcoop/ui":
-        specifier: 2.0.1
-        version: 2.0.1(a42f1bd46a91f3e083f3bbbf6d88fc00)
+        specifier: 2.0.2
+        version: 2.0.2(a42f1bd46a91f3e083f3bbbf6d88fc00)
       "@duneanalytics/client-sdk":
         specifier: ^0.2.5
         version: 0.2.5
@@ -522,10 +522,10 @@ packages:
         integrity: sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==,
       }
 
-  "@breadcoop/ui@2.0.1":
+  "@breadcoop/ui@2.0.2":
     resolution:
       {
-        integrity: sha512-lvVgyfPpdIi/JW5kOdpoeRpYNaWaAr1/zRxQhfAmvCI0XKYDG+p0NA4zyFeECsZzo7elKmaGj/B1kqnRViiGiA==,
+        integrity: sha512-5HDWww1REKLV2YN2qSmk/rzxohtll2MgK5bxufy3s7ycCUONxcJU1m+9I0ALfdrmaTWA+6KiSz2NwhyuJ3TfBw==,
       }
     peerDependencies:
       "@phosphor-icons/react": ^2.1.1
@@ -11334,7 +11334,7 @@ snapshots:
     dependencies:
       "@noble/curves": 1.9.7
 
-  "@breadcoop/ui@2.0.1(a42f1bd46a91f3e083f3bbbf6d88fc00)":
+  "@breadcoop/ui@2.0.2(a42f1bd46a91f3e083f3bbbf6d88fc00)":
     dependencies:
       "@phosphor-icons/react": 2.1.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       "@privy-io/react-auth": 3.18.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)))(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.91.2)(@tanstack/react-query@5.91.2(react@19.1.0))(@types/react@19.2.14)(@upstash/redis@1.37.0)(bufferutil@4.1.0)(react-dom@19.1.0(react@19.1.0))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@6.0.6)(zod@4.3.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,4 +25,4 @@ allowBuilds:
 overrides:
   "@noble/curves": ">=1.9.0"
   "semver": ">=6.3.2"
-  "@breadcoop/ui": "2.0.1"
+  "@breadcoop/ui": "2.0.2"

--- a/src/app/account/_components/account-overview-card.tsx
+++ b/src/app/account/_components/account-overview-card.tsx
@@ -26,17 +26,17 @@ const SmallButton = ({
   onClick: () => void;
   tone: "primary" | "ink";
 }) => (
-  <button
+  <LocalButton
     type="button"
+    size="sm"
+    variant="light"
     onClick={onClick}
-    className={`border bg-paper-main px-4 py-1.5 text-sm font-bold shadow-[2px_2px_0px_#595959] transition-opacity hover:opacity-90 ${
-      tone === "primary"
-        ? "border-primary-blue text-primary-blue"
-        : "border-surface-ink text-surface-ink"
+    className={`text-sm font-bold ${
+      tone === "primary" ? "border-primary-blue text-primary-blue" : ""
     }`}
   >
     {children}
-  </button>
+  </LocalButton>
 );
 
 const Column = ({


### PR DESCRIPTION
## What & why

The account page's **Deposit / Withdraw** buttons didn't react on press — they were a custom `<button>` with a static offset shadow and no `active:` state, unlike the design-system buttons (Sign In, Create new Stack) whose shadow collapses on press.

Closes #143

## Change

`src/app/account/_components/account-overview-card.tsx` — re-implement `SmallButton` on top of `LocalButton` (v2 `Button`) with `size="sm"`, inheriting `active:shadow-none` + `transition-all` and the small offset shadow. Outlined look kept via `variant="light"` (Withdraw = ink) and a `border-primary-blue text-primary-blue` override (Deposit = blue). Same handlers/labels.

Audit: all other recent-page buttons already use `LocalButton`; `SmallButton` was the only custom-shadow button.

## Verification
- `tsc` + `eslint` clean.
- On the Netlify preview (`/account`, signed in): pressing Deposit/Withdraw collapses the shadow just like Create new Stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
