### PR TITLE
feat(cards): abstract BREAD token on stack group cards

### DIFF
--- a/src/components/stack.tsx
+++ b/src/components/stack.tsx
@@ -93,21 +93,21 @@ const Stack = ({
       className: "",
     },
     {
-      label: `Token: BREAD`,
-      icon: <CoinIcon />,
-      className: "hidden md:flex",
-    },
-    {
-      label: `${formatBalance(Number(depositAmount) * stack.totalMember, 2)} BREAD ${
+      label: `$${formatBalance(Number(depositAmount), 2)} ${
         parseCircleIntervalToDate(stack.depositInterval).label
       }`,
       icon: <CoinsIcon />,
       className: "",
     },
     {
-      label: `Goal: ${formatBalance(totalGoal, 2)} BREAD`,
+      label: `Pay out: $${formatBalance(Number(depositAmount) * stack.totalMember, 2)}`,
+      icon: <CoinIcon />,
+      className: "",
+    },
+    {
+      label: `Stack volume: $${formatBalance(totalGoal, 2)}`,
       icon: <CalendarIcon />,
-      className: "hidden md:flex",
+      className: "",
     },
   ];
 
@@ -191,7 +191,7 @@ const Stack = ({
             )}
           </p>
           <Body className="flex items-center justify-start gap-1 text-surface-grey">
-            <span className="text-[0.625rem]">Total BREAD stacked</span>
+            <span className="text-[0.625rem]">Total stacked</span>
             <span>
               <QuestionIcon size={16} className="fill-surface-grey" />
             </span>


### PR DESCRIPTION
## What & why

Stack group cards exposed the "BREAD" token and used fundraising wording. This abstracts the token and clarifies the figures.

Closes #145

## Changes (`src/components/stack.tsx`, card `items`)

- Remove the **Token: BREAD** row.
- **Weekly amount** now shows the **per-member** deposit (dropped `× members`) with `$` instead of `BREAD` → `$<deposit> <interval>`.
- Add a **Pay out** row = members × per-member weekly deposit → `Pay out: $<amount>`.
- Rename **Goal** → **Stack volume**, `$` instead of `BREAD`.
- Mobile label "Total BREAD stacked" → "Total stacked".
- All four rows now show on mobile (Token/Goal were desktop-only).

Scope: the `Stack` card component only, which covers the dashboard and account placements. Stack detail page intentionally untouched.

## Verification
- `tsc` + `eslint` clean.
- On the Netlify preview (`/`, logged-out shows All Stacks cards): cards show Members, `$… <interval>` (per member), `Pay out: $…`, `Stack volume: $…`, and no "Token"/"BREAD".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
