### PR TITLE
Add general invite link with owner approval for Stacks

### DIFF
--- a/src/app/api/stacks/join-requests/route.ts
+++ b/src/app/api/stacks/join-requests/route.ts
@@ -1,0 +1,472 @@
+import { serverEnv } from "@/lib/envs/server";
+import { createClient } from "@supabase/supabase-js";
+import { NextRequest, NextResponse } from "next/server";
+import { createErrorResponse } from "../../utils";
+import {
+  Database,
+  JoinRequestInviteLink,
+  SupabaseInviteLink,
+} from "@/lib/supabase";
+import { savingCirclesAbi } from "@/lib/abis/saving-circles";
+import { getServerPublicClient } from "@/lib/server-viem-client";
+import { recoverTypedDataAddress, type Address } from "viem";
+
+const supabaseAdmin = createClient<Database>(
+  serverEnv.NEXT_PUBLIC_SUPABASE_URL,
+  serverEnv.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SAVING_CIRCLES_CONTRACT_ADDRESS =
+  serverEnv.NEXT_PUBLIC_SAVING_CIRCLES_CONTRACT_ADDRESS as Address;
+
+const INVITE_DOMAIN_NAME = "StacksInvite";
+const INVITE_DOMAIN_VERSION = "1";
+
+const recoverInviteSigner = ({
+  chainId,
+  circleId,
+  nonce,
+  signature,
+}: {
+  chainId: number;
+  circleId: bigint;
+  nonce: bigint;
+  signature: `0x${string}`;
+}) =>
+  recoverTypedDataAddress({
+    domain: {
+      name: INVITE_DOMAIN_NAME,
+      version: INVITE_DOMAIN_VERSION,
+      chainId,
+      verifyingContract: SAVING_CIRCLES_CONTRACT_ADDRESS,
+    },
+    types: {
+      Invite: [
+        { name: "id", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+      ],
+    },
+    primaryType: "Invite",
+    message: {
+      id: circleId,
+      nonce,
+    },
+    signature,
+  });
+
+async function getUserByPrivyId(privyUserId: string) {
+  const { data, error } = await supabaseAdmin
+    .from("users")
+    .select("id, wallet_address")
+    .eq("privy_user_id", privyUserId)
+    .single();
+
+  if (error || !data) return null;
+
+  return data;
+}
+
+async function getCircleOwner(circleId: bigint) {
+  const publicClient = getServerPublicClient();
+
+  try {
+    const circle = await publicClient.readContract({
+      address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+      abi: savingCirclesAbi,
+      functionName: "getCircle",
+      args: [circleId],
+    });
+
+    return circle.owner;
+  } catch (err) {
+    console.error(
+      `getCircleOwner(${circleId}) failed against ${SAVING_CIRCLES_CONTRACT_ADDRESS} on chain ${serverEnv.NEXT_PUBLIC_CHAIN_ID}:`,
+      err
+    );
+    return null;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body !== "object") {
+      return createErrorResponse("Invalid request body");
+    }
+
+    const { circleId, privyUserId } = body as {
+      circleId?: string;
+      privyUserId?: string;
+    };
+
+    if (!circleId || typeof circleId !== "string") {
+      return createErrorResponse("circleId is required and must be a string");
+    }
+
+    if (!privyUserId || typeof privyUserId !== "string") {
+      return createErrorResponse(
+        "privyUserId is required and must be a string"
+      );
+    }
+
+    const user = await getUserByPrivyId(privyUserId);
+
+    if (!user || !user.wallet_address) {
+      return createErrorResponse(
+        "No onboarded wallet found for this user",
+        404
+      );
+    }
+
+    const parsedId = BigInt(circleId);
+    const owner = await getCircleOwner(parsedId);
+
+    if (!owner) {
+      return createErrorResponse("This stack does not exist", 404);
+    }
+
+    const publicClient = getServerPublicClient();
+    const [isMember, isActive] = await Promise.all([
+      publicClient.readContract({
+        address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+        abi: savingCirclesAbi,
+        functionName: "isMember",
+        args: [parsedId, user.wallet_address as `0x${string}`],
+      }),
+      publicClient.readContract({
+        address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+        abi: savingCirclesAbi,
+        functionName: "isActive",
+        args: [parsedId],
+      }),
+    ]);
+
+    if (isMember) {
+      return createErrorResponse("You are already a member of this stack");
+    }
+
+    if (isActive) {
+      return createErrorResponse("This stack has already launched");
+    }
+
+    const { data: existing } = await supabaseAdmin
+      .from("join_requests")
+      .select("*")
+      .eq("stack_id", circleId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (existing && existing.status !== "rejected") {
+      return NextResponse.json({ success: true, request: existing });
+    }
+
+    const row: Database["public"]["Tables"]["join_requests"]["Insert"] = {
+      stack_id: circleId,
+      user_id: user.id,
+      wallet_address: user.wallet_address,
+      status: "pending",
+      invite_link: null,
+      requested_at: new Date().toISOString(),
+      decided_at: null,
+    };
+
+    const { data: saved, error: upsertError } = await supabaseAdmin
+      .from("join_requests")
+      .upsert(row, { onConflict: "stack_id,user_id" })
+      .select("*")
+      .single();
+
+    if (upsertError || !saved) {
+      console.error("Failed to save join request:", upsertError);
+      return createErrorResponse("Failed to save join request", 500);
+    }
+
+    return NextResponse.json({ success: true, request: saved });
+  } catch (err) {
+    console.error("Create join request endpoint error:", err);
+    return createErrorResponse("Internal server error", 500);
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const circleId = req.nextUrl.searchParams.get("circleId");
+    const privyUserId = req.nextUrl.searchParams.get("privyUserId");
+
+    if (!circleId) return createErrorResponse("circleId is required");
+    if (!privyUserId) return createErrorResponse("privyUserId is required");
+
+    const user = await getUserByPrivyId(privyUserId);
+
+    if (!user || !user.wallet_address) {
+      return createErrorResponse(
+        "No onboarded wallet found for this user",
+        404
+      );
+    }
+
+    const owner = await getCircleOwner(BigInt(circleId));
+
+    if (!owner) return createErrorResponse("This stack does not exist", 404);
+
+    const isOwner = owner.toLowerCase() === user.wallet_address.toLowerCase();
+
+    if (isOwner) {
+      const { data, error } = await supabaseAdmin
+        .from("join_requests")
+        .select("*")
+        .eq("stack_id", circleId)
+        .in("status", ["pending", "approved"])
+        .order("requested_at", { ascending: true });
+
+      if (error) {
+        console.error("Failed to fetch join requests:", error);
+        return createErrorResponse("Failed to fetch join requests", 500);
+      }
+
+      return NextResponse.json({ success: true, isOwner, requests: data });
+    }
+
+    const { data } = await supabaseAdmin
+      .from("join_requests")
+      .select("*")
+      .eq("stack_id", circleId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    return NextResponse.json({
+      success: true,
+      isOwner,
+      requests: data ? [data] : [],
+    });
+  } catch (err) {
+    console.error("Fetch join requests endpoint error:", err);
+    return createErrorResponse("Internal server error", 500);
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body !== "object") {
+      return createErrorResponse("Invalid request body");
+    }
+
+    const { circleId, requestId, privyUserId, action, inviteLink } = body as {
+      circleId?: string;
+      requestId?: string;
+      privyUserId?: string;
+      action?: "approve" | "reject";
+      inviteLink?: JoinRequestInviteLink & { signature?: string };
+    };
+
+    if (!circleId || typeof circleId !== "string") {
+      return createErrorResponse("circleId is required and must be a string");
+    }
+    if (!requestId || typeof requestId !== "string") {
+      return createErrorResponse("requestId is required and must be a string");
+    }
+    if (!privyUserId || typeof privyUserId !== "string") {
+      return createErrorResponse(
+        "privyUserId is required and must be a string"
+      );
+    }
+    if (action !== "approve" && action !== "reject") {
+      return createErrorResponse('action must be "approve" or "reject"');
+    }
+
+    const user = await getUserByPrivyId(privyUserId);
+
+    if (!user || !user.wallet_address) {
+      return createErrorResponse(
+        "No onboarded wallet found for this user",
+        404
+      );
+    }
+
+    const parsedId = BigInt(circleId);
+    const owner = await getCircleOwner(parsedId);
+
+    if (!owner) return createErrorResponse("This stack does not exist", 404);
+
+    if (owner.toLowerCase() !== user.wallet_address.toLowerCase()) {
+      return createErrorResponse(
+        "Only the stack owner can review join requests",
+        403
+      );
+    }
+
+    const { data: request, error: fetchError } = await supabaseAdmin
+      .from("join_requests")
+      .select("*")
+      .eq("id", requestId)
+      .eq("stack_id", circleId)
+      .single();
+
+    if (fetchError || !request) {
+      return createErrorResponse("Join request not found", 404);
+    }
+
+    if (request.status !== "pending") {
+      return createErrorResponse("This request has already been decided");
+    }
+
+    if (action === "reject") {
+      const { data: updated, error: updateError } = await supabaseAdmin
+        .from("join_requests")
+        .update({ status: "rejected", decided_at: new Date().toISOString() })
+        .eq("id", requestId)
+        .select("*")
+        .single();
+
+      if (updateError || !updated) {
+        console.error("Failed to reject join request:", updateError);
+        return createErrorResponse("Failed to reject join request", 500);
+      }
+
+      return NextResponse.json({ success: true, request: updated });
+    }
+
+    if (
+      !inviteLink ||
+      typeof inviteLink.nonce !== "string" ||
+      typeof inviteLink.signature !== "string" ||
+      typeof inviteLink.short !== "string" ||
+      typeof inviteLink.long !== "string"
+    ) {
+      return createErrorResponse(
+        "inviteLink { nonce, signature, short, long } is required to approve"
+      );
+    }
+
+    const nonce = BigInt(inviteLink.nonce);
+    const signer = await recoverInviteSigner({
+      chainId: serverEnv.NEXT_PUBLIC_CHAIN_ID,
+      circleId: parsedId,
+      nonce,
+      signature: inviteLink.signature as `0x${string}`,
+    }).catch(() => null);
+
+    if (!signer || signer.toLowerCase() !== owner.toLowerCase()) {
+      return createErrorResponse("Invalid invite signature");
+    }
+
+    const publicClient = getServerPublicClient();
+    const nonceUsed = await publicClient.readContract({
+      address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+      abi: savingCirclesAbi,
+      functionName: "usedNonces",
+      args: [parsedId, nonce],
+    });
+
+    if (nonceUsed) {
+      return createErrorResponse("This invite nonce has already been used");
+    }
+
+    const { data: stackMetadata, error: metadataError } = await supabaseAdmin
+      .from("stacks_metadata")
+      .select("expected_members, invite_links")
+      .eq("id", circleId)
+      .single();
+
+    if (metadataError || !stackMetadata) {
+      return createErrorResponse("Stack metadata not found", 404);
+    }
+
+    const existingLinks =
+      (stackMetadata.invite_links as SupabaseInviteLink[]) ?? [];
+
+    if (existingLinks.some((link) => link.long.includes(`nonce=${nonce}`))) {
+      return createErrorResponse("This invite nonce is already in use");
+    }
+
+    const memberCount = await publicClient.readContract({
+      address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+      abi: savingCirclesAbi,
+      functionName: "getCircleMembers",
+      args: [parsedId],
+    });
+
+    // Only count seats already promised through *this* review flow — not
+    // stack-creation's pre-generated batch invites, which sit unused in
+    // invite_links regardless of whether the owner ever hands them out and
+    // would otherwise make committedSeats == expected_members immediately on
+    // every stack, permanently blocking approvals.
+    const { data: approvedRequests } = await supabaseAdmin
+      .from("join_requests")
+      .select("invite_link")
+      .eq("stack_id", circleId)
+      .eq("status", "approved");
+
+    const approvedNonces = (approvedRequests ?? [])
+      .map((r) => r.invite_link?.nonce)
+      .filter((n): n is string => !!n)
+      .map((n) => BigInt(n));
+
+    const redeemedFlags = await Promise.all(
+      approvedNonces.map((approvedNonce) =>
+        publicClient.readContract({
+          address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+          abi: savingCirclesAbi,
+          functionName: "usedNonces",
+          args: [parsedId, approvedNonce],
+        })
+      )
+    );
+
+    const openSeats = redeemedFlags.filter((used) => !used).length;
+    const committedSeats = memberCount.length + openSeats;
+
+    if (
+      stackMetadata.expected_members > 0 &&
+      committedSeats >= stackMetadata.expected_members
+    ) {
+      return createErrorResponse("This stack's member cap has been reached");
+    }
+
+    const newLink: SupabaseInviteLink = {
+      short: inviteLink.short,
+      long: inviteLink.long,
+      used: false,
+    };
+
+    const { error: linksUpdateError } = await supabaseAdmin
+      .from("stacks_metadata")
+      .update({ invite_links: [...existingLinks, newLink] })
+      .eq("id", circleId);
+
+    if (linksUpdateError) {
+      console.error("Failed to append invite link:", linksUpdateError);
+      return createErrorResponse("Failed to save invite link", 500);
+    }
+
+    const approvedInviteLink: JoinRequestInviteLink = {
+      short: inviteLink.short,
+      long: inviteLink.long,
+      nonce: inviteLink.nonce,
+    };
+
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from("join_requests")
+      .update({
+        status: "approved",
+        invite_link: approvedInviteLink,
+        decided_at: new Date().toISOString(),
+      })
+      .eq("id", requestId)
+      .select("*")
+      .single();
+
+    if (updateError || !updated) {
+      console.error("Failed to approve join request:", updateError);
+      return createErrorResponse("Failed to approve join request", 500);
+    }
+
+    return NextResponse.json({ success: true, request: updated });
+  } catch (err) {
+    console.error("Decide join request endpoint error:", err);
+    return createErrorResponse("Internal server error", 500);
+  }
+}

--- a/src/app/stacks/[id]/_components/copy-link.tsx
+++ b/src/app/stacks/[id]/_components/copy-link.tsx
@@ -6,6 +6,42 @@ import { useCopyToClipboard } from "@breadcoop/ui";
 import { CheckIcon, CopyIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 
+export const CopyGeneralInviteLink = ({ id }: { id: string }) => {
+  const [currentUrl, setCurrentUrl] = useState("");
+  const { isShortening, result: shortenedUrl } = useShortenedUrl(currentUrl);
+  const { copy, copied } = useCopyToClipboard({
+    textToCopy: shortenedUrl,
+  });
+
+  useEffect(() => {
+    setCurrentUrl(`${window.location.origin}/stacks/join?circleId=${id}`);
+  }, [id]);
+
+  const onCopy = () => {
+    if (isShortening) return;
+
+    copy();
+  };
+
+  return (
+    <LocalButton
+      variant="light"
+      className={`h-8 border px-4 ${copied ? "text-system-green" : ""}`}
+      leftIcon={
+        copied ? (
+          <CheckIcon className="fill-system-green" />
+        ) : (
+          <CopyIcon className="fill-primary-blue" />
+        )
+      }
+      onClick={onCopy}
+      disabled={isShortening}
+    >
+      {copied ? "Copied!" : isShortening ? "Loading..." : "Copy invite link"}
+    </LocalButton>
+  );
+};
+
 export const CopyStackLink = () => {
   const [currentUrl, setCurrentUrl] = useState("");
   const { isShortening, result: shortenedUrl } = useShortenedUrl(currentUrl);

--- a/src/app/stacks/[id]/_components/members.tsx
+++ b/src/app/stacks/[id]/_components/members.tsx
@@ -6,6 +6,8 @@ import {
   UsersIcon,
 } from "@phosphor-icons/react/ssr";
 import MembersInfo from "./members-info";
+import PendingJoinRequests from "./pending-join-requests";
+import { CopyGeneralInviteLink } from "./copy-link";
 import { Address, formatEther } from "viem";
 import { useCircleMembersWithBalances } from "@/hooks/use-circle-members";
 import { useReadContracts } from "wagmi";
@@ -130,6 +132,24 @@ const StackMembers = ({
           </>
         )}
       </div>
+
+      {isOwner && circleStatus === "pending-start" && (
+        <>
+          <div className="flex items-center justify-between gap-2 border-t border-paper-2 pt-4">
+            <Body className="text-surface-grey">
+              Share this link so people can request to join
+            </Body>
+            <CopyGeneralInviteLink id={id} />
+          </div>
+          <PendingJoinRequests
+            id={id}
+            stackName={stackMetadata?.stackname ?? `Stack ${id}`}
+            expectedMembers={stackMetadata?.expected_members ?? 0}
+            depositAmount={circle.depositAmount}
+            depositInterval={circle.depositInterval}
+          />
+        </>
+      )}
 
       <MembersInfo
         owner={circle.owner}

--- a/src/app/stacks/[id]/_components/pending-join-requests.tsx
+++ b/src/app/stacks/[id]/_components/pending-join-requests.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import PendingInviteLink from "@/components/pending-invite-link";
+import LocalButton from "@/components/button";
+import { useModal } from "@/components/modal/context";
+import { buildInviteUrl } from "@/components/modal/modals/stack-result";
+import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
+import { savingCirclesAbi } from "@/lib/abis/saving-circles";
+import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
+import { clientEnv } from "@/lib/env";
+import { JoinRequestRow } from "@/lib/supabase";
+import { formatAddress } from "@/utils/address";
+import { getDefaultChainId } from "@/utils/chain";
+import { getIntervalBySeconds } from "@/utils/deposit-interval";
+import { shortenUrl } from "@/utils/shorten";
+import { formatShortDate } from "@/utils/time";
+import { Body, formatBalance, Heading3 } from "@breadcoop/ui";
+import { CheckIcon, XIcon } from "@phosphor-icons/react";
+import { usePrivy, useSignTypedData } from "@privy-io/react-auth";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { formatEther } from "viem";
+import { usePublicClient } from "wagmi";
+
+const INVITE_DOMAIN_NAME = "StacksInvite";
+const INVITE_DOMAIN_VERSION = "1";
+const DEFAULT_CHAIN = getDefaultChainId();
+const isLocal = clientEnv.NEXT_PUBLIC_NODE_ENV === "local";
+
+interface JoinRequestsResponse {
+  isOwner: boolean;
+  requests: JoinRequestRow[];
+}
+
+const PendingJoinRequests = ({
+  id,
+  stackName,
+  expectedMembers,
+  depositAmount,
+  depositInterval,
+}: {
+  id: string;
+  stackName: string;
+  expectedMembers: number;
+  depositAmount: bigint;
+  depositInterval: bigint;
+}) => {
+  const { user: privyUser } = usePrivy();
+  const queryClient = useQueryClient();
+
+  const queryKey = ["join-requests", id, privyUser?.id];
+
+  const { data } = useQuery<JoinRequestsResponse>({
+    queryKey,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/stacks/join-requests?circleId=${id}&privyUserId=${privyUser?.id}`
+      );
+      const body = await res.json();
+
+      if (!res.ok || !body.success) {
+        throw new Error(body.error ?? "Failed to load join requests");
+      }
+
+      return { isOwner: body.isOwner, requests: body.requests };
+    },
+    enabled: !!privyUser?.id,
+    refetchInterval: 30_000,
+  });
+
+  const pending = (data?.requests ?? []).filter(
+    (request) => request.status === "pending"
+  );
+
+  const onDecided = () => {
+    queryClient.invalidateQueries({ queryKey });
+    queryClient.invalidateQueries({ queryKey: ["stack-metadata", id] });
+  };
+
+  if (!data?.isOwner || pending.length === 0) return null;
+
+  return (
+    <section className="p-4 flex flex-col gap-4 border-t border-paper-2">
+      <Heading3 className="pb-1 leading-[100%] text-2xl">
+        Requests to join ({pending.length})
+      </Heading3>
+      <div className="*:mb-2 *:last:mb-0">
+        {pending.map((request) => (
+          <JoinRequestRowItem
+            key={request.id}
+            id={id}
+            stackName={stackName}
+            expectedMembers={expectedMembers}
+            depositAmount={depositAmount}
+            depositInterval={depositInterval}
+            request={request}
+            onDecided={onDecided}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+const JoinRequestRowItem = ({
+  id,
+  stackName,
+  expectedMembers,
+  depositAmount,
+  depositInterval,
+  request,
+  onDecided,
+}: {
+  id: string;
+  stackName: string;
+  expectedMembers: number;
+  depositAmount: bigint;
+  depositInterval: bigint;
+  request: JoinRequestRow;
+  onDecided: () => void;
+}) => {
+  const { user: privyUser } = usePrivy();
+  const { setModal } = useModal();
+  const publicClient = usePublicClient({ chainId: getDefaultChainId() });
+  const { signTypedData } = useSignTypedData();
+  const blockTimestamp = useBlockTimestamp();
+  const [busy, setBusy] = useState<"approving" | "rejecting" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [approvedLink, setApprovedLink] = useState<string | null>(null);
+
+  const decide = async (
+    action: "approve" | "reject",
+    inviteLink?: {
+      nonce: string;
+      signature: string;
+      short: string;
+      long: string;
+    }
+  ) => {
+    const res = await fetch("/api/stacks/join-requests", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        circleId: id,
+        requestId: request.id,
+        privyUserId: privyUser?.id,
+        action,
+        inviteLink,
+      }),
+    });
+    const body = await res.json();
+
+    if (!res.ok || !body.success) {
+      throw new Error(body.error ?? `Failed to ${action} request`);
+    }
+  };
+
+  const approve = async () => {
+    if (!publicClient) return;
+
+    setBusy("approving");
+    setError(null);
+
+    try {
+      const circleId = BigInt(id);
+      let candidate = BigInt(isLocal ? blockTimestamp : Date.now());
+
+      while (
+        await publicClient.readContract({
+          address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+          abi: savingCirclesAbi,
+          functionName: "usedNonces",
+          args: [circleId, candidate],
+        })
+      ) {
+        candidate += BigInt(1);
+      }
+
+      // signTypedData serializes the message for the embedded wallet and
+      // can't handle raw BigInts — mirrors the conversion in
+      // stack-result.tsx's generateInvites.
+      const toTypedDataUint = (value: bigint) =>
+        value < BigInt(Number.MAX_SAFE_INTEGER)
+          ? Number(value)
+          : value.toString();
+
+      const { signature } = await signTypedData(
+        {
+          domain: {
+            name: INVITE_DOMAIN_NAME,
+            version: INVITE_DOMAIN_VERSION,
+            chainId: DEFAULT_CHAIN,
+            verifyingContract: SAVING_CIRCLES_CONTRACT_ADDRESS,
+          },
+          types: {
+            Invite: [
+              { name: "id", type: "uint256" },
+              { name: "nonce", type: "uint256" },
+            ],
+          },
+          primaryType: "Invite",
+          message: {
+            id: toTypedDataUint(circleId),
+            nonce: toTypedDataUint(candidate),
+          },
+        },
+        { uiOptions: { showWalletUIs: false } }
+      );
+
+      const duration =
+        getIntervalBySeconds(Number(depositInterval))?.label ?? "-";
+
+      const long = buildInviteUrl(
+        `${window.location.origin}/stacks/join`,
+        id,
+        candidate,
+        signature,
+        stackName,
+        expectedMembers,
+        duration,
+        formatBalance(+formatEther(depositAmount), 2)
+      );
+      const short = await shortenUrl(long, { check: false });
+
+      await decide("approve", {
+        nonce: candidate.toString(),
+        signature,
+        short,
+        long,
+      });
+
+      setApprovedLink(short);
+      onDecided();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      setError(err?.message || "Failed to approve request");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const reject = () => {
+    setModal({
+      type: "REJECT_JOIN_REQUEST_WARNING",
+      onConfirm: async () => {
+        setBusy("rejecting");
+        setError(null);
+
+        try {
+          await decide("reject");
+          onDecided();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+          setError(err?.message || "Failed to reject request");
+        } finally {
+          setBusy(null);
+        }
+      },
+    });
+  };
+
+  if (approvedLink) {
+    return <PendingInviteLink link={approvedLink} shorten={false} />;
+  }
+
+  return (
+    <div className="bg-paper-1 p-3 flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <Body bold>
+          {formatAddress(request.wallet_address as `0x${string}`)}
+        </Body>
+        <Body className="text-surface-grey text-xs">
+          Requested {formatShortDate(new Date(request.requested_at))}
+        </Body>
+      </div>
+      <div className="flex items-center justify-start gap-2">
+        <LocalButton
+          onClick={approve}
+          leftIcon={<CheckIcon size={16} />}
+          isLoading={busy === "approving"}
+          disabled={busy !== null}
+          className="text-sm"
+        >
+          Approve
+        </LocalButton>
+        <LocalButton
+          onClick={reject}
+          variant="destructive"
+          leftIcon={<XIcon size={16} />}
+          isLoading={busy === "rejecting"}
+          disabled={busy !== null}
+          className="text-sm"
+        >
+          Reject
+        </LocalButton>
+      </div>
+      {error && <Body className="text-system-red text-xs">{error}</Body>}
+    </div>
+  );
+};
+
+export default PendingJoinRequests;

--- a/src/app/stacks/join/_components/general-invite-flow.tsx
+++ b/src/app/stacks/join/_components/general-invite-flow.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Loading from "@/app/loading";
+import { useStackSupabase } from "@/hooks/use-stack-supabase";
+import { savingCirclesAbi } from "@/lib/abis/saving-circles";
+import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
+import { getDefaultChainId } from "@/utils/chain";
+import { getIntervalBySeconds } from "@/utils/deposit-interval";
+import { Body } from "@breadcoop/ui";
+import { formatEther, zeroAddress } from "viem";
+import { useReadContract } from "wagmi";
+import InviteDetails from "./invite-details";
+import RequestToJoin from "./request-to-join";
+
+const GeneralInviteFlow = ({ circleId }: { circleId: string }) => {
+  const { data: stackMetadata, isLoading: isLoadingMetadata } =
+    useStackSupabase(circleId);
+
+  const { data: circle, isLoading: isLoadingCircle } = useReadContract({
+    abi: savingCirclesAbi,
+    address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+    functionName: "getCircle",
+    args: [BigInt(circleId || "0")],
+    chainId: getDefaultChainId(),
+    query: { enabled: !!circleId },
+  });
+
+  if (isLoadingMetadata || isLoadingCircle) {
+    return (
+      <div className="flex items-center justify-center">
+        <Loading />
+      </div>
+    );
+  }
+
+  if (!stackMetadata || !circle || circle.owner === zeroAddress) {
+    return (
+      <Body className="text-system-red text-center">
+        This stack does not exist.
+      </Body>
+    );
+  }
+
+  const duration =
+    getIntervalBySeconds(Number(circle.depositInterval))?.label ?? "-";
+
+  return (
+    <>
+      <InviteDetails
+        name={stackMetadata.stackname}
+        circleId={circleId}
+        duration={duration}
+        members={String(stackMetadata.expected_members)}
+        deposit={formatEther(circle.depositAmount)}
+      />
+      <RequestToJoin circleId={circleId} />
+    </>
+  );
+};
+
+export default GeneralInviteFlow;

--- a/src/app/stacks/join/_components/interface.ts
+++ b/src/app/stacks/join/_components/interface.ts
@@ -1,8 +1,8 @@
 export interface CircleParams {
   circleId: string;
   name: string;
-  nonce: string;
-  signature: string;
+  nonce?: string;
+  signature?: string;
   duration: string;
   members: string;
   deposit: string;

--- a/src/app/stacks/join/_components/join-flow.tsx
+++ b/src/app/stacks/join/_components/join-flow.tsx
@@ -1,0 +1,32 @@
+import Alert from "@/components/alert";
+import AcceptInvite from "./accept-invite";
+import GeneralInviteFlow from "./general-invite-flow";
+import { CircleParams } from "./interface";
+import InviteDetails from "./invite-details";
+
+const JoinFlow = ({ searchParams }: { searchParams: CircleParams }) => {
+  const hasDirectInvite = Boolean(searchParams.nonce && searchParams.signature);
+
+  if (hasDirectInvite) {
+    return (
+      <>
+        <InviteDetails {...searchParams} />
+        <Alert
+          closeAble={false}
+          variant="warning"
+          title="IMPORTANT: This invite can only be accepted once!"
+          description="Each invite is unique and can only be accepted once."
+        />
+        <AcceptInvite
+          circleId={searchParams.circleId}
+          nonce={searchParams.nonce}
+          signature={searchParams.signature}
+        />
+      </>
+    );
+  }
+
+  return <GeneralInviteFlow circleId={searchParams.circleId} />;
+};
+
+export default JoinFlow;

--- a/src/app/stacks/join/_components/request-to-join.tsx
+++ b/src/app/stacks/join/_components/request-to-join.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import Loading from "@/app/loading";
+import Alert from "@/components/alert";
+import LocalButton from "@/components/button";
+import { savingCirclesAbi } from "@/lib/abis/saving-circles";
+import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
+import { getDefaultChainId } from "@/utils/chain";
+import { Body, LoginButton, useConnectedUser } from "@breadcoop/ui";
+import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useReadContract } from "wagmi";
+import AcceptInvite from "./accept-invite";
+
+interface JoinRequest {
+  id: string;
+  status: "pending" | "approved" | "rejected";
+  invite_link: { short: string; long: string; nonce: string } | null;
+}
+
+const LoadingBlock = () => (
+  <div className="flex items-center justify-center">
+    <Loading />
+  </div>
+);
+
+const RequestToJoin = ({ circleId }: { circleId: string }) => {
+  const { user } = useConnectedUser();
+  const { user: privyUser } = usePrivy();
+  const queryClient = useQueryClient();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const address = user.status === "CONNECTED" ? user.address : undefined;
+  const parsedId = BigInt(circleId || "0");
+
+  const { data: isMember, error: isMemberError } = useReadContract({
+    abi: savingCirclesAbi,
+    address: SAVING_CIRCLES_CONTRACT_ADDRESS,
+    functionName: "isMember",
+    args: [parsedId, address as `0x${string}`],
+    query: {
+      enabled:
+        (user.status === "CONNECTED" || user.status === "UNSUPPORTED_CHAIN") &&
+        !!address,
+    },
+    chainId: getDefaultChainId(),
+  });
+
+  const requestQueryKey = ["join-request", circleId, privyUser?.id];
+
+  const { data: myRequest, isLoading: isLoadingRequest } = useQuery({
+    queryKey: requestQueryKey,
+    queryFn: async (): Promise<JoinRequest | null> => {
+      const res = await fetch(
+        `/api/stacks/join-requests?circleId=${circleId}&privyUserId=${privyUser?.id}`
+      );
+      const body = await res.json();
+
+      if (!res.ok || !body.success) {
+        throw new Error(body.error ?? "Failed to load request status");
+      }
+
+      return body.requests[0] ?? null;
+    },
+    enabled: !!privyUser?.id && isMember === false,
+  });
+
+  const requestToJoin = async () => {
+    if (!privyUser?.id) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/stacks/join-requests", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ circleId, privyUserId: privyUser.id }),
+      });
+      const body = await res.json();
+
+      if (!res.ok || !body.success) {
+        throw new Error(body.error ?? "Failed to request to join");
+      }
+
+      queryClient.setQueryData(requestQueryKey, body.request);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      setError(err?.message || "Failed to request to join");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (user.status !== "CONNECTED") {
+    return <LoginButton app="stacks" status={user.status} />;
+  }
+
+  if (!address) {
+    return (
+      <Body className="text-center">Reconnect your wallet to continue.</Body>
+    );
+  }
+
+  if (typeof isMember === "boolean") {
+    if (isMember) {
+      return (
+        <Body className="text-system-green text-center">
+          You are already a member of this circle!
+        </Body>
+      );
+    }
+
+    if (isLoadingRequest) return <LoadingBlock />;
+
+    if (myRequest?.status === "approved" && myRequest.invite_link) {
+      const signature =
+        new URL(myRequest.invite_link.long).searchParams.get("signature") ?? "";
+
+      return (
+        <>
+          <Alert
+            closeAble={false}
+            variant="success"
+            title="You're approved!"
+            description="Accept your invite below to join this stack."
+          />
+          <AcceptInvite
+            circleId={circleId}
+            nonce={myRequest.invite_link.nonce}
+            signature={signature}
+          />
+        </>
+      );
+    }
+
+    if (myRequest?.status === "pending") {
+      return (
+        <Body className="text-center text-surface-grey">
+          Request sent. You&apos;ll be able to join once the stack creator
+          approves it.
+        </Body>
+      );
+    }
+
+    if (myRequest?.status === "rejected") {
+      return (
+        <Body className="text-system-red text-center">
+          Your request to join this stack wasn&apos;t approved.
+        </Body>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-2">
+        <LocalButton
+          onClick={requestToJoin}
+          leftIcon={submitting ? undefined : <PaperPlaneTiltIcon size={24} />}
+          className="w-full"
+          variant="positive"
+          isLoading={submitting}
+        >
+          Request to join
+        </LocalButton>
+        {error && <Body className="text-system-red text-center">{error}</Body>}
+      </div>
+    );
+  }
+
+  if (isMemberError) {
+    return (
+      <Body className="text-system-red text-center">
+        Unable to get data! Please refresh the page!
+      </Body>
+    );
+  }
+
+  return <LoadingBlock />;
+};
+
+export default RequestToJoin;

--- a/src/app/stacks/join/page.tsx
+++ b/src/app/stacks/join/page.tsx
@@ -3,9 +3,7 @@ import { Body, Heading1 } from "@breadcoop/ui";
 import { ConfettiIcon } from "@phosphor-icons/react/dist/ssr";
 import { JoinPageSettings } from "./_components/settings";
 import { CircleParams } from "./_components/interface";
-import InviteDetails from "./_components/invite-details";
-import Alert from "@/components/alert";
-import AcceptInvite from "./_components/accept-invite";
+import JoinFlow from "./_components/join-flow";
 
 export const metadata = generateMetadata({
   title: "Join a Stack - Bread Cooperative",
@@ -33,19 +31,7 @@ export default async function Page(props: {
           </Body>
         </div>
 
-        <InviteDetails {...searchParams} />
-
-        <Alert
-          closeAble={false}
-          variant="warning"
-          title="IMPORTANT: This invite can only be accepted once!"
-          description="Each invite is unique and can only be accepted once."
-        />
-        <AcceptInvite
-          circleId={searchParams.circleId}
-          nonce={searchParams.nonce}
-          signature={searchParams.signature}
-        />
+        <JoinFlow searchParams={searchParams} />
 
         <Body>
           Note: You can also access your member invite links through your Stacks

--- a/src/components/modal/context.tsx
+++ b/src/components/modal/context.tsx
@@ -85,6 +85,11 @@ export type StartStackWarningModalState = {
   onConfirm: () => void;
 };
 
+export type RejectJoinRequestWarningModalState = {
+  type: "REJECT_JOIN_REQUEST_WARNING";
+  onConfirm: () => void;
+};
+
 export type WithdrawBreadModalState = {
   type: "WITHDRAW_BREAD";
 };
@@ -148,6 +153,7 @@ export type ModalState =
   | StackInitFailedModalState
   | StackFailedModalState
   | StartStackWarningModalState
+  | RejectJoinRequestWarningModalState
   | WithdrawBreadModalState
   | WalletFundingStatusModalState
   | ReminderModalState

--- a/src/components/modal/modals/reject-join-request-warning.tsx
+++ b/src/components/modal/modals/reject-join-request-warning.tsx
@@ -1,0 +1,44 @@
+import { Body } from "@breadcoop/ui";
+import { ModalContainer, ModalHeader } from "../components";
+import { RejectJoinRequestWarningModalState, useModal } from "../context";
+import LocalButton from "@/components/button";
+
+const RejectJoinRequestWarningModal = ({
+  modalState,
+}: {
+  modalState: RejectJoinRequestWarningModalState;
+}) => {
+  const { setModal } = useModal();
+
+  const reject = () => {
+    setModal(null);
+    modalState.onConfirm();
+  };
+
+  return (
+    <ModalContainer>
+      <ModalHeader title="Reject this request?" />
+      <Body className="text-center text-surface-grey">
+        This person will not be able to join the stack unless they request to
+        join again.
+      </Body>
+      <div className="flex flex-col gap-3">
+        <LocalButton
+          variant="destructive"
+          className="font-bold w-full"
+          onClick={reject}
+        >
+          Reject request
+        </LocalButton>
+        <LocalButton
+          className="font-bold w-full"
+          onClick={() => setModal(null)}
+        >
+          Cancel
+        </LocalButton>
+      </div>
+    </ModalContainer>
+  );
+};
+
+export default RejectJoinRequestWarningModal;

--- a/src/components/modal/modals/stack-result.tsx
+++ b/src/components/modal/modals/stack-result.tsx
@@ -39,7 +39,7 @@ const INVITE_DOMAIN_NAME = "StacksInvite";
 const INVITE_DOMAIN_VERSION = "1";
 const DEFAULT_CHAIN = getDefaultChainId();
 
-function buildInviteUrl(
+export function buildInviteUrl(
   baseUrl: string,
   circleId: string,
   nonce: bigint,

--- a/src/components/modal/presenter.tsx
+++ b/src/components/modal/presenter.tsx
@@ -22,6 +22,7 @@ import LiFiSwapModal from "../lifi/swap-modal";
 import InstallPeerModal from "../peer/install-modal";
 import FundWithConnectedWalletModalAmount from "./modals/fund-wallet/fund-with-connected-wallet-modal-amount";
 import StartStackWarningModal from "./modals/start-stack-warning";
+import RejectJoinRequestWarningModal from "./modals/reject-join-request-warning";
 import AutomaticClaimsModal from "./modals/automatic-claims";
 import VisitorOnboarding from "../onboard/visitor-onboard-modal";
 import AutomaticDepositsModal from "@/components/automatic-deposits/modal";
@@ -67,6 +68,9 @@ const ModalPresenter = () => {
               )}
               {modalState.type === "START_STACK_WARNING" && (
                 <StartStackWarningModal modalState={modalState} />
+              )}
+              {modalState.type === "REJECT_JOIN_REQUEST_WARNING" && (
+                <RejectJoinRequestWarningModal modalState={modalState} />
               )}
               {modalState.type === "WITHDRAW_BREAD" && <WithdrawBreadModal />}
               {modalState.type === "NEW_USER_ONBOARDING" && (

--- a/src/lib/envs/server.ts
+++ b/src/lib/envs/server.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
   AUTOMATIC_FUNDING_PRIVATE_KEY: z.string(),
   NEXT_PUBLIC_CHAIN_ID: z.coerce.number(),
   NEXT_PUBLIC_BREAD_TOKEN_ADDRESS: z.string(),
+  NEXT_PUBLIC_SAVING_CIRCLES_CONTRACT_ADDRESS: z.string(),
   NEXT_PUBLIC_PRIVY_APP_ID: z.string(),
 });
 

--- a/src/lib/server-viem-client.ts
+++ b/src/lib/server-viem-client.ts
@@ -1,0 +1,17 @@
+import { createPublicClient, fallback, http } from "viem";
+import { serverEnv } from "@/lib/envs/server";
+import { networks } from "@/utils/network";
+
+const SEPOLIA_CHAIN_ID = 11155111;
+
+export const getServerPublicClient = () => {
+  const chain =
+    networks[serverEnv.NEXT_PUBLIC_CHAIN_ID as keyof typeof networks].chain;
+
+  const transport =
+    chain.id === SEPOLIA_CHAIN_ID
+      ? fallback([http(serverEnv.SEPOLIA_RPC_URL), http()])
+      : http();
+
+  return createPublicClient({ chain, transport });
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -19,6 +19,25 @@ export type SupabaseStackMetadata = {
   invite_links: SupabaseInviteLink[];
 };
 
+export type JoinRequestStatus = "pending" | "approved" | "rejected";
+
+export type JoinRequestInviteLink = {
+  short: string;
+  long: string;
+  nonce: string;
+};
+
+export type JoinRequestRow = {
+  id: string;
+  stack_id: string;
+  user_id: string;
+  wallet_address: string;
+  status: JoinRequestStatus;
+  invite_link: JoinRequestInviteLink | null;
+  requested_at: string;
+  decided_at: string | null;
+};
+
 // Mirror the supabase generated-types shape (Relationships per table,
 // Views/Functions/Enums/CompositeTypes on the schema) or queries degrade.
 export type Database = {
@@ -85,6 +104,31 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "user_stacks_stack_id_fkey";
+            columns: ["stack_id"];
+            isOneToOne: false;
+            referencedRelation: "stacks_metadata";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      join_requests: {
+        Row: JoinRequestRow;
+        Insert: Pick<
+          JoinRequestRow,
+          "stack_id" | "user_id" | "wallet_address"
+        > &
+          Partial<
+            Pick<
+              JoinRequestRow,
+              "id" | "status" | "invite_link" | "requested_at" | "decided_at"
+            >
+          >;
+        Update: Partial<
+          Pick<JoinRequestRow, "status" | "invite_link" | "decided_at">
+        >;
+        Relationships: [
+          {
+            foreignKeyName: "join_requests_stack_id_fkey";
             columns: ["stack_id"];
             isOneToOne: false;
             referencedRelation: "stacks_metadata";

--- a/supabase/migrations/20260717000100_join_requests.sql
+++ b/supabase/migrations/20260717000100_join_requests.sql
@@ -1,0 +1,23 @@
+-- General invite link: off-chain ledger of requests to join a stack,
+-- reviewed by the stack owner before an on-chain invite is issued. Carries
+-- other users' wallet addresses and pending activity, which is more
+-- sensitive than the public stacks_metadata rows, so unlike that table this
+-- one has no anon/authenticated grants at all — every read and write goes
+-- through the service-role API route (src/app/api/stacks/join-requests).
+
+create table if not exists public.join_requests (
+  id uuid primary key default gen_random_uuid(),
+  stack_id text not null references public.stacks_metadata(id),
+  user_id uuid not null references public.users(id) on delete cascade,
+  wallet_address text not null,
+  status text not null default 'pending'
+    check (status in ('pending', 'approved', 'rejected')),
+  invite_link jsonb,
+  requested_at timestamptz not null default now(),
+  decided_at timestamptz,
+  unique (stack_id, user_id)
+);
+
+alter table public.join_requests enable row level security;
+
+revoke all on public.join_requests from anon, authenticated;


### PR DESCRIPTION
Closes: #99 
Stack creators can now share a single general /stacks/join?circleId= link instead of only pre-signed single-use invites. Visitors land on a preview and request to join; the owner reviews pending requests and approves (signs a per-requester invite, reusing the existing redeemInvite flow) or rejects them, gated by the stack's configured member cap.