### PR TITLE
fix: show completed stack as Finished instead of Not started

### DIFF
--- a/src/lib/get-user-circle-status.ts
+++ b/src/lib/get-user-circle-status.ts
@@ -118,6 +118,23 @@ export const getUserCircleStatus = ({
   }
 
   if (circleState === CircleState.NotStarted) {
+    // A cleanly completed circle also reports `NotStarted`: when the final
+    // member claims, the contract sets `isActive = false`, and `circleState()`
+    // has no terminal "completed" value, so a finished circle is neither
+    // decommissioned nor active and falls through to `NotStarted`. Distinguish
+    // the two via `effectiveCircleStartTime`, which is only non-zero once the
+    // circle has actually been started — so `NotStarted` with a start time set
+    // means "finished", not "pending start".
+    if (circle.circleInfo.effectiveCircleStartTime > BigInt(0)) {
+      return {
+        status: "finished",
+        statusLabel: "Finished",
+        variant: "success",
+        title: "Circle completed successfully",
+        desc: "Everyone has deposited and withdrawn their funds. No more actions can be taken.",
+      };
+    }
+
     return {
       status: "pending-start",
       statusLabel: "Not started",


### PR DESCRIPTION
Fixes #160 (frontend mitigation).

## Problem

When a stack completes successfully (all members deposited and claimed), the UI showed **"Not started"** and re-enabled the **Start** button.

The contract's `circleState()` has no terminal "completed" value: once the last member claims, `_withdraw` sets `isActive = false`, so a finished circle is neither decommissioned nor active and falls through to `NotStarted`. The frontend mapped `NotStarted` straight to `pending-start` (which drives the "Not started" label and the Start button) before the unreachable `finished` branch could run.

## Fix

In `getUserCircleStatus`, split the `NotStarted` branch on `effectiveCircleStartTime`, which is only non-zero once the circle has actually been started. `NotStarted` **with** a start time set is a completed circle → return `finished`; otherwise it's genuinely pending start. This corrects the label and hides the Start button (gated on `pending-start`).

## Scope / follow-up

This is a **frontend-only** mitigation and ships without a redeploy. We should do changes in the contracts as

- `circleState()` needs a real terminal state for a completed circle.
- `start()` only checks `isActive`, so it will still accept a restart of a completed circle if called directly.
