### PR TITLE
feat: clarify BREAD/xDAI on deposit & withdraw flows

### DIFF
--- a/src/components/bread-info-note.tsx
+++ b/src/components/bread-info-note.tsx
@@ -1,0 +1,32 @@
+import { Body } from "@breadcoop/ui";
+import { InfoIcon } from "@phosphor-icons/react";
+import { ReactNode } from "react";
+import { LINKS } from "@/constants/links";
+
+/**
+ * Informational note explaining that amounts are BREAD (a USD-pegged token on
+ * Gnosis), shown on the deposit/withdraw flows to reduce confusion now that the
+ * UI displays USD. Links the BREAD token docs for the technical details.
+ */
+const BreadInfoNote = ({ children }: { children: ReactNode }) => (
+  <div className="flex items-start gap-2 bg-paper-1 p-3">
+    <InfoIcon
+      size={20}
+      weight="fill"
+      className="mt-0.5 shrink-0 text-primary-blue"
+    />
+    <Body className="text-xs text-surface-grey-2">
+      {children}{" "}
+      <a
+        href={LINKS.docsBreadToken}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-bold text-primary-blue underline"
+      >
+        Learn more about BREAD &amp; xDAI
+      </a>
+    </Body>
+  </div>
+);
+
+export default BreadInfoNote;

--- a/src/components/modal/modals/fund-wallet/fund-wallet.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-wallet.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { useWatchFundedXdai } from "@/hooks/use-watch-funded-xdai";
 import { Body, useConnectedUser } from "@breadcoop/ui";
 import Alert from "@/components/alert";
+import BreadInfoNote from "@/components/bread-info-note";
 import { PeerIntentFulfilledResult } from "@zkp2p/sdk";
 
 const FundWallet = ({ modalState }: { modalState: FundWalletModalState }) => {
@@ -41,6 +42,11 @@ const FundWallet = ({ modalState }: { modalState: FundWalletModalState }) => {
       <Body className="-mt-4">
         Send xDAI to your wallet and automatically get BREAD
       </Body>
+      <BreadInfoNote>
+        You fund with <strong>xDAI</strong> on the Gnosis network, which is
+        automatically converted to <strong>BREAD</strong> — worth $1 each (1:1
+        with USD). Your balance is shown in USD.
+      </BreadInfoNote>
       <div className={result ? "" : ""}>
         {result && (
           <div>

--- a/src/components/modal/modals/withdraw-bread.tsx
+++ b/src/components/modal/modals/withdraw-bread.tsx
@@ -17,6 +17,7 @@ import { useAccount, useReadContract } from "wagmi";
 import { Address, erc20Abi, isAddress } from "viem";
 import LocalButton from "@/components/button";
 import Loading from "@/app/loading";
+import BreadInfoNote from "@/components/bread-info-note";
 import { cn } from "@/lib/utils";
 import { BREAD_TOKEN_ADDRESS } from "@/lib/constants";
 import { getDefaultChainId } from "@/utils/chain";
@@ -192,6 +193,11 @@ const WithdrawBreadModal = () => {
         </>
       ) : (
         <form className="*:mb-6" onSubmit={withdraw}>
+          <BreadInfoNote>
+            You&apos;re withdrawing <strong>BREAD</strong> — worth $1 each (1:1
+            with USD) — from the Gnosis network. Amounts are shown in USD, but
+            you receive BREAD in your wallet.
+          </BreadInfoNote>
           <div>
             <Label htmlFor="address">Recipient Address</Label>
             <div className="relative">


### PR DESCRIPTION
## What & why

Now that the UI shows **USD**, users could be confused about what they're actually depositing/withdrawing. This adds a short explainer (with a docs link) to the **fund** and **withdraw** flows so they understand that amounts are **BREAD** — a token pegged **1:1 to USD** — and that BREAD/xDAI live on the **Gnosis network**.

## Changes

- **New reusable `BreadInfoNote`** (`src/components/bread-info-note.tsx`) — an info note that links [`docs.bread.coop/bread-token`](https://docs.bread.coop/bread-token/) for the technical details.
- **Fund ("Deposit") modal** — notes that you fund with **xDAI on Gnosis**, auto-converted to **BREAD** (worth $1 each, 1:1 with USD); balance shown in USD. (Complements the existing "Always get xDAI" warning.)
- **Withdraw modal** — notes that you're withdrawing **BREAD** (1:1 with USD) on Gnosis; amounts show in USD but you receive BREAD in your wallet.

## Verification
- `tsc` + `eslint`/lint-staged clean.
- Both modals require a connected wallet to open, so please eyeball them on the Netlify preview (account widget → **Deposit** / **Withdraw**).

## Notes
- Scoped to the account-level **Fund** and **Withdraw** cards (per the design discussion). The per-stack "Pay your deposit" modal was intentionally left out — easy to add the same note there if you want it too.
- Independent of #147 (that PR abstracts BREAD→$ elsewhere; this only touches the two modals it doesn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
