### PR TITLE
feat: compact displayed amounts with a millify helper

### DIFF
--- a/src/app/account/_components/account-overview-card.tsx
+++ b/src/app/account/_components/account-overview-card.tsx
@@ -3,7 +3,8 @@
 import Loading from "@/app/loading";
 import { useModal } from "@/components/modal/context";
 import { useUserCirclesList } from "@/hooks/use-user-circles-list";
-import { Body, formatBalance } from "@breadcoop/ui";
+import { millify } from "@/utils/format-amount";
+import { Body } from "@breadcoop/ui";
 import {
   CoinsIcon,
   HandDepositIcon,
@@ -50,9 +51,7 @@ const Column = ({
 }) => (
   <div className="flex flex-col gap-3">
     <Body className="text-surface-grey">{label}</Body>
-    <p className="text-2xl font-bold text-surface-ink">
-      ${formatBalance(amount, 2)}
-    </p>
+    <p className="text-2xl font-bold text-surface-ink">${millify(amount, 2)}</p>
     {cta}
   </div>
 );
@@ -99,7 +98,7 @@ const AccountOverviewCard = ({
         </Body>
         <div className="flex flex-wrap items-center gap-4">
           <p className="text-4xl font-bold text-surface-ink md:text-5xl">
-            ${formatBalance(totalHeld, 2)}
+            ${millify(totalHeld, 2)}
           </p>
           {isOwner && (
             <div className="flex gap-2">

--- a/src/app/new/_components/form/overview.tsx
+++ b/src/app/new/_components/form/overview.tsx
@@ -27,6 +27,7 @@ import { parseContractError } from "@/utils/parse-contract-error";
 import { getIntervalById, splitIntervalId } from "@/utils/deposit-interval";
 import { CREATE_ERRORS } from "@/lib/contract-errors";
 import { getDefaultChainId } from "@/utils/chain";
+import { formatAmount } from "@/utils/format-amount";
 
 const parseCreateError = (error: unknown) =>
   parseContractError(
@@ -193,11 +194,7 @@ const StackOverviewForm = ({ onBack }: { onBack: () => void }) => {
           }
           amount={freqDeposit}
         />
-        <BreadRow
-          label="Total Deposited per member"
-          amount={total.toFixed(2)}
-          colored
-        />
+        <BreadRow label="Total Deposited per member" amount={total} colored />
       </div>
       <div className="px-6 py-3 bg-paper-1">
         <Body className="text-xs text-surface-grey-2">
@@ -280,7 +277,7 @@ function BreadRow({
           colored ? "border-system-green" : "border-paper-2"
         }`}
       >
-        <Body bold>${amount}</Body>
+        <Body bold>${formatAmount(Number(amount))}</Body>
       </div>
     </div>
   );

--- a/src/app/stacks/[id]/_components/back-meta.tsx
+++ b/src/app/stacks/[id]/_components/back-meta.tsx
@@ -10,6 +10,7 @@ import { ICircleStatus } from "@/interfaces/circle";
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
 import { useCircleState } from "@/hooks/use-circles-state";
 import { CircleState } from "@/lib/circle-state";
+import { formatAmount } from "@/utils/format-amount";
 
 type CircleData = Exclude<
   ReturnType<typeof useUserCircleData>["circleData"],
@@ -37,8 +38,8 @@ const BackMeta = ({
   const nowSeconds = BigInt(Math.floor(now / 1000));
   const { circleState } = useCircleState(circle?.circleId);
 
-  const depositAmount = `$${formatEther(
-    circle?.circleInfo.depositAmount ?? BigInt(0)
+  const depositAmount = `$${formatAmount(
+    +formatEther(circle?.circleInfo.depositAmount ?? BigInt(0))
   )}`;
 
   const circleStatus: ICircleStatus = circle

--- a/src/app/stacks/[id]/_components/members-info.tsx
+++ b/src/app/stacks/[id]/_components/members-info.tsx
@@ -21,7 +21,8 @@ import { useCircleState } from "@/hooks/use-circles-state";
 import { CircleState } from "@/lib/circle-state";
 import { useMembersClaimed } from "@/hooks/use-members-claimed";
 import { formatRelativeTime, formatShortDate } from "@/utils/time";
-import { Body, Chip, formatBalance } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
+import { Body, Chip } from "@breadcoop/ui";
 import { Address, formatEther } from "viem";
 
 const FAILED_STATUSES: ICircleStatus[] = [
@@ -247,7 +248,7 @@ function MemberInfoContent({
 
   if (isFailedStack) {
     if (fundsDeposited.data) {
-      memberTotal = formatBalance(
+      memberTotal = formatAmount(
         +formatEther(
           (
             fundsDeposited.data.depositsByMember[

--- a/src/app/stacks/[id]/_components/overall-stacked.tsx
+++ b/src/app/stacks/[id]/_components/overall-stacked.tsx
@@ -3,7 +3,8 @@
 import { useFundsDeposited } from "@/hooks/use-funds-deposited";
 import { ICircleStatus } from "@/interfaces/circle";
 import { IFormattedUserCircleStatusResult } from "@/lib/get-user-circle-status";
-import { Body, formatBalance } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
+import { Body } from "@breadcoop/ui";
 import { formatEther } from "viem";
 
 const failedStatuses: ICircleStatus[] = [
@@ -39,13 +40,13 @@ const OverallStacked = ({
   });
 
   if (!isFailedStack) {
-    return <Body>${formatBalance(+totalAmountStackedByMembers, 2)}</Body>;
+    return <Body>${formatAmount(+totalAmountStackedByMembers, 2)}</Body>;
   }
 
   if (fundsDeposited.data) {
     return (
       <Body>
-        ${formatBalance(+formatEther(fundsDeposited.data.totalDeposit), 2)}
+        ${formatAmount(+formatEther(fundsDeposited.data.totalDeposit), 2)}
       </Body>
     );
   }

--- a/src/app/stacks/[id]/_components/overview.tsx
+++ b/src/app/stacks/[id]/_components/overview.tsx
@@ -4,7 +4,6 @@ import { useUserCircleData } from "@/hooks/use-user-circle-data";
 import {
   Body,
   cn,
-  formatBalance,
   Heading3,
   LoginButton,
   useConnectedUser,
@@ -27,6 +26,7 @@ import { useStackSupabase } from "@/hooks/use-stack-supabase";
 import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
 import { savingCirclesAbi } from "@/lib/abis/saving-circles";
 import { getDefaultChainId } from "@/utils/chain";
+import { formatAmount } from "@/utils/format-amount";
 import { useReadContracts } from "wagmi";
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
 import { useFundsDeposited } from "@/hooks/use-funds-deposited";
@@ -218,7 +218,7 @@ const Overview = ({
           <span className="text-surface-grey">Total Deposit</span>
           <span className="inline-flex items-center justify-start">
             <span className="font-bold mt-[0.2rem]">
-              ${formatBalance(+formatEther(poolBalance), 2)}
+              ${formatAmount(+formatEther(poolBalance), 2)}
             </span>
           </span>
         </Body>
@@ -297,8 +297,8 @@ const Overview = ({
             {connectedUser.user.status === "CONNECTED" ? (
               <DepositButton
                 className="font-bold w-full"
-                label={`Deposit $${formatEther(
-                  circle.circleInfo.depositAmount
+                label={`Deposit $${formatAmount(
+                  +formatEther(circle.circleInfo.depositAmount)
                 )}`}
                 amount={circle.circleInfo.depositAmount}
                 tokenAddress={circle.circleInfo.token}

--- a/src/app/stacks/[id]/_components/stack-details.tsx
+++ b/src/app/stacks/[id]/_components/stack-details.tsx
@@ -13,13 +13,11 @@ import {
   getIntervalBySeconds,
   splitIntervalId,
 } from "@/utils/deposit-interval";
-import {
-  Body,
-  formatBalance,
-  FormattedDecimalNumber,
-  Heading3,
-  useConnectedUser,
-} from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
+import { amountSizeStep } from "@/utils/amount-size";
+import { cn } from "@/lib/utils";
+import { FormattedDecimalNumber } from "@/components/bread-ui-kit/formatted-decimal-number";
+import { Body, Heading3, useConnectedUser } from "@breadcoop/ui";
 import { CalendarDotsIcon } from "@phosphor-icons/react/ssr";
 import { ReactNode } from "react";
 import { formatEther } from "viem";
@@ -31,6 +29,14 @@ const failedStatuses: ICircleStatus[] = [
   "failed",
   "finished",
 ];
+
+// Now that this page shows amounts in full, the hero steps down a size once the
+// figure gets long, so "$1,250,000.00" doesn't run past its container.
+const HERO_SIZES = {
+  base: { integral: "text-[80px]", decimal: "text-[48px]" },
+  sm: { integral: "text-[56px]", decimal: "text-[34px]" },
+  xs: { integral: "text-[40px]", decimal: "text-[24px]" },
+} as const;
 
 const StackDetailsTotal = ({
   intervalLabel,
@@ -61,14 +67,16 @@ const StackDetailsTotal = ({
     );
   }
 
+  const heroSize = HERO_SIZES[amountSizeStep(+depositPerRound)];
+
   return (
     <div className="flex flex-col gap-6 mb-3 md:mb-0 md:flex-1 md:justify-end">
       <div className="flex items-center justify-start gap-x-4 flex-wrap">
         <FormattedDecimalNumber
           value={depositPerRound}
           unit="$"
-          integralPartClassName="text-[80px]"
-          decimalPartClassName="text-[48px] text-surface-grey-2"
+          integralPartClassName={heroSize.integral}
+          decimalPartClassName={cn(heroSize.decimal, "text-surface-grey-2")}
         />
         <div>
           <Body className="text-surface-grey-2">
@@ -138,7 +146,7 @@ const StackDetailsBreakdown = ({
     <div className="md:flex-1">
       <StackDetailsBreakdownRow label={`${intervalLabel} deposit`}>
         <p className="text-h2 text-2xl leading-6 tracking-[-2%]">
-          ${formatBalance(+formatEther(circle.depositAmount), 2)}
+          ${formatAmount(+formatEther(circle.depositAmount), 2)}
         </p>
       </StackDetailsBreakdownRow>
       <StackDetailsBreakdownRow label="Members deposit every">

--- a/src/app/stacks/[id]/_components/total-stacked.tsx
+++ b/src/app/stacks/[id]/_components/total-stacked.tsx
@@ -1,11 +1,5 @@
-import {
-  Body,
-  formatBalance,
-  FormattedDecimalNumber,
-  Heading3,
-  LoginButton,
-  useConnectedUser,
-} from "@breadcoop/ui";
+import { Body, Heading3, LoginButton, useConnectedUser } from "@breadcoop/ui";
+import { FormattedDecimalNumber } from "@/components/bread-ui-kit/formatted-decimal-number";
 import { useCircleStatus } from "@/hooks/use-circle-status";
 import Loading from "@/app/loading";
 import { cn } from "@/lib/utils";
@@ -16,6 +10,8 @@ import { Address, formatEther } from "viem";
 import ClaimButton from "@/components/claim-button";
 import { useGetLastClaimed } from "@/hooks/use-get-last-claimed";
 import { formatRelativeTime } from "@/utils/time";
+import { formatAmount } from "@/utils/format-amount";
+import { amountSizeStep } from "@/utils/amount-size";
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
 import { AutomaticClaim } from "./automatic-claim";
 import { useCircleState } from "@/hooks/use-circles-state";
@@ -24,6 +20,14 @@ import {
   FAILED_STACK_STATUSES,
   getUserCircleStatus,
 } from "@/lib/get-user-circle-status";
+
+// Steps down a size once the claimable figure gets long, so it doesn't run past
+// the card. See stack-details for the same ladder at the larger hero size.
+const CLAIM_SIZES = {
+  base: { integral: "text-[3rem]", decimal: "text-[2.21rem]" },
+  sm: { integral: "text-[2.25rem]", decimal: "text-[1.66rem]" },
+  xs: { integral: "text-[1.6rem]", decimal: "text-[1.2rem]" },
+} as const;
 
 const TotalStacked = ({
   id,
@@ -72,6 +76,8 @@ const TotalStacked = ({
     }
   }
 
+  const claimSize = CLAIM_SIZES[amountSizeStep(Number(amount))];
+
   return (
     <section
       className={cn(
@@ -105,15 +111,21 @@ const TotalStacked = ({
                   <FormattedDecimalNumber
                     value={amount}
                     unit="$"
-                    integralPartClassName="text-[3rem] text-surface-ink"
-                    decimalPartClassName="text-[2.21rem] text-surface-grey-2"
+                    integralPartClassName={cn(
+                      claimSize.integral,
+                      "text-surface-ink"
+                    )}
+                    decimalPartClassName={cn(
+                      claimSize.decimal,
+                      "text-surface-grey-2"
+                    )}
                   />
                 )}
                 <div className="flex flex-col gap-2 items-center -mt-4">
                   <Body className="text-surface-grey-2">
                     {amount === "-"
                       ? "-"
-                      : `$${formatBalance(Number(amount), 2)}`}
+                      : `$${formatAmount(Number(amount), 2)}`}
                   </Body>
                   <Body className="text-xs">{msg}</Body>
                 </div>

--- a/src/app/stacks/join/_components/invite-details.tsx
+++ b/src/app/stacks/join/_components/invite-details.tsx
@@ -4,7 +4,8 @@ import {
   AccordionHeader,
   AccordionItem,
 } from "@/components/accordion";
-import { Body, formatBalance } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
+import { Body } from "@breadcoop/ui";
 import { CircleParams } from "./interface";
 
 type InviteDetailsProps = Pick<
@@ -19,6 +20,10 @@ export default function InviteDetails({
   members,
   deposit,
 }: InviteDetailsProps) {
+  // Invites generated before the deposit was written raw carry a comma-grouped
+  // amount (e.g. "90,999,999.00"), which Number() alone reads as NaN.
+  const depositAmount = Number((deposit ?? "").replace(/,/g, ""));
+
   return (
     <div className="border-t border-blue-0 pt-6">
       <Body className="text-center mb-6">
@@ -39,11 +44,11 @@ export default function InviteDetails({
               <RowDetail label="Duration" body={duration} />
               <RowDetail
                 label="Est. Deposit amount"
-                body={`$${formatBalance(+deposit)}`}
+                body={`$${formatAmount(depositAmount)}`}
               />
               <RowDetail
                 label="Stack goal"
-                body={`$${formatBalance(Number(members) ** 2 * Number(deposit), 2)}`}
+                body={`$${formatAmount(Number(members) ** 2 * depositAmount, 2)}`}
               />
             </div>
           </AccordionContent>

--- a/src/components/Navbar/claimable-widget.tsx
+++ b/src/components/Navbar/claimable-widget.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { useUserCirclesList } from "@/hooks/use-user-circles-list";
-import {
-  FormattedDecimalNumber,
-  NavAccountWidgetItem,
-  useConnectedUser,
-} from "@breadcoop/ui";
+import { FormattedDecimalNumber } from "@/components/bread-ui-kit/formatted-decimal-number";
+import { NavAccountWidgetItem, useConnectedUser } from "@breadcoop/ui";
 import { HandArrowDownIcon } from "@phosphor-icons/react";
 import { zeroAddress } from "viem";
 
@@ -32,9 +29,10 @@ const ClaimableWidget = () => {
         appIconColor="text-primary-blue"
       >
         <FormattedDecimalNumber
-          className="text-[#EA5817]"
+          className="text-core-orange"
           value={withdrawableAmount}
           withBreadIcon
+          compact
         />
       </NavAccountWidgetItem>
     </>

--- a/src/components/automatic-deposits/modal/shared.tsx
+++ b/src/components/automatic-deposits/modal/shared.tsx
@@ -7,13 +7,14 @@ import {
   formatSecondsHuman,
   getIntervalBySeconds,
 } from "@/utils/deposit-interval";
+import { formatAmount } from "@/utils/format-amount";
 import { networks } from "@/utils/network";
-import { Body, formatBalance, Logo } from "@breadcoop/ui";
+import { Body, Logo } from "@breadcoop/ui";
 import { ReactNode } from "react";
 import { formatEther } from "viem";
 
 export const breadLabel = (value: bigint) =>
-  `${formatBalance(Number(formatEther(value)), 2)} BREAD`;
+  `${formatAmount(Number(formatEther(value)), 2)} BREAD`;
 
 export const getIntervalLabels = (depositInterval: bigint) => {
   const seconds = Number(depositInterval);

--- a/src/components/bread-ui-kit/formatted-decimal-number.tsx
+++ b/src/components/bread-ui-kit/formatted-decimal-number.tsx
@@ -1,0 +1,62 @@
+import { Body, Logo } from "@breadcoop/ui";
+import { cn } from "@/lib/utils";
+import { formatAmount, millify } from "@/utils/format-amount";
+
+interface FormattedDecimalNumberProps {
+  value: number | string;
+  className?: string;
+  integralPartClassName?: string;
+  decimalPartClassName?: string;
+  withBreadIcon?: boolean;
+  breadIconClassName?: string;
+  breadSize?: number;
+  unit?: string;
+  /** Shorten to "50k" past 10K. For tight spaces only; defaults to the full amount. */
+  compact?: boolean;
+}
+
+/**
+ * Fork of `@breadcoop/ui`'s FormattedDecimalNumber that formats with
+ * {@link formatAmount} / {@link millify} instead of `formatBalance`.
+ *
+ * The shrunk decimal style exists to de-emphasise cents, so it is only applied
+ * to exact amounts. Once millify compacts ("10.5k"), the fraction carries
+ * magnitude rather than cents and the whole figure stays in the integral style
+ * — otherwise "$10.5k" would read as "$10" at a glance.
+ */
+export function FormattedDecimalNumber({
+  value,
+  className,
+  integralPartClassName,
+  decimalPartClassName,
+  withBreadIcon,
+  breadIconClassName,
+  breadSize = 24,
+  unit = "",
+  compact = false,
+}: FormattedDecimalNumberProps) {
+  const parsedValue = typeof value === "number" ? value : parseFloat(value);
+  const formattedValue = compact
+    ? millify(parsedValue)
+    : formatAmount(parsedValue);
+  const isCompact = /\D$/.test(formattedValue);
+  const [integerPart, decimalPart] = formattedValue.split(".");
+
+  return (
+    <div className="inline-flex items-center justify-start gap-2">
+      {withBreadIcon && (
+        <Logo className={breadIconClassName} size={breadSize} />
+      )}
+      <Body bold className={cn(withBreadIcon && "mt-[0.2rem]", className)}>
+        <span className={cn("text-base", integralPartClassName)}>
+          {`${unit}${isCompact ? formattedValue : integerPart}`.trim()}
+        </span>
+        {!isCompact && (
+          <span className={cn("text-xs", decimalPartClassName)}>
+            .{decimalPart}
+          </span>
+        )}
+      </Body>
+    </div>
+  );
+}

--- a/src/components/bread-ui-kit/navbar/account-card-mobile.tsx
+++ b/src/components/bread-ui-kit/navbar/account-card-mobile.tsx
@@ -3,11 +3,11 @@
 import { Address } from "viem";
 import {
   CopyButtonIcon,
-  FormattedDecimalNumber,
   Logo,
   useBreadBalance,
   useConnectedUser,
 } from "@breadcoop/ui";
+import { FormattedDecimalNumber } from "../formatted-decimal-number";
 import { ArrowUpRightIcon } from "@phosphor-icons/react";
 import { blo } from "blo";
 import { cn } from "@/lib/utils";
@@ -68,6 +68,7 @@ const AccountCardMobile = ({
         <FormattedDecimalNumber
           value={BREAD}
           unit="$"
+          compact
           integralPartClassName="text-[1.8rem]"
           decimalPartClassName="text-[1.35rem]"
         />

--- a/src/components/bread-ui-kit/navbar/account-menu.tsx
+++ b/src/components/bread-ui-kit/navbar/account-menu.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { ReactNode, useRef, useState } from "react";
-import { Body, FormattedDecimalNumber, useBreadBalance } from "@breadcoop/ui";
+import { Body, useBreadBalance } from "@breadcoop/ui";
+import { FormattedDecimalNumber } from "../formatted-decimal-number";
 import { CaretDownIcon } from "@phosphor-icons/react";
 import { blo } from "blo";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,7 @@ const AccountMenu = ({
           <FormattedDecimalNumber
             value={BREAD}
             unit="$"
+            compact
             integralPartClassName="text-base"
             decimalPartClassName="text-xs"
           />

--- a/src/components/bread-ui-kit/navbar/account-widget.tsx
+++ b/src/components/bread-ui-kit/navbar/account-widget.tsx
@@ -5,6 +5,7 @@ import { Address } from "viem";
 import {
   Body,
   CopyButtonIcon,
+  formatBalance,
   NavAccountWidgetItem,
   useBreadBalance,
   useConnectedUser,
@@ -74,7 +75,7 @@ const AccountWidget = ({
         appIconColor="text-primary-blue"
         label="Balance"
       >
-        <Body>${BREAD}</Body>
+        <Body>${formatBalance(+BREAD)}</Body>
       </NavAccountWidgetItem>
       {widgetItems}
       <NavAccountWidgetItem

--- a/src/components/claim-button.tsx
+++ b/src/components/claim-button.tsx
@@ -7,7 +7,7 @@ import { useModal } from "./modal/context";
 import { cn } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { Address } from "viem";
-import { formatBalance } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
 import { useSavingCirclesTx } from "@/hooks/use-saving-circles-tx";
 import { parseContractError } from "@/utils/parse-contract-error";
 import { CLAIM_ERRORS } from "@/lib/contract-errors";
@@ -80,7 +80,7 @@ const ClaimButton = ({
       onClick={claim}
       disabled={claiming}
     >
-      {label || `Claim ${formatBalance(amount, 2)} BREAD`}
+      {label || `Claim ${formatAmount(amount, 2)} BREAD`}
     </LocalButton>
   );
 };

--- a/src/components/deposit-button.tsx
+++ b/src/components/deposit-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ButtonProps, formatBalance, useConnectedUser } from "@breadcoop/ui";
+import { ButtonProps, useConnectedUser } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
 import { useModal } from "./modal/context";
 import { useReadContract } from "wagmi";
 import { Address, encodeFunctionData, erc20Abi, formatEther } from "viem";
@@ -69,7 +70,7 @@ const DepositButton = ({
   const hasInsufficientBalance = !!userAddress && balance < amount;
 
   const missingAmount = hasInsufficientBalance
-    ? formatBalance(Number(formatEther(amount - balance)), 2)
+    ? formatAmount(Number(formatEther(amount - balance)), 2)
     : null;
 
   const deposit = async () => {

--- a/src/components/modal/modals/fund-wallet/fund-with-connected-wallet-modal-amount.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-with-connected-wallet-modal-amount.tsx
@@ -5,7 +5,8 @@ import NumericInput from "@/components/numeric-input";
 import { SubmitEventHandler, useState } from "react";
 import { ModalContainer, ModalHeader } from "../../components";
 import LocalButton from "@/components/button";
-import { Body, formatBalance, Logo, useConnectedUser } from "@breadcoop/ui";
+import { Body, Logo, useConnectedUser } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
 import { useModal } from "../../context";
 import { formatEther, parseEther } from "viem";
 import {
@@ -155,7 +156,7 @@ const FundWithConnectedWalletModalAmount = ({
           Balance:{" "}
           {tokenBalance.isLoading
             ? "Loading..."
-            : formatBalance(formattedBalance)}
+            : formatAmount(formattedBalance)}
         </Body>
         <div className="lifted-button-container mt-6">
           <LocalButton

--- a/src/components/modal/modals/fund-wallet/fund-with-connected-wallet.tsx
+++ b/src/components/modal/modals/fund-wallet/fund-with-connected-wallet.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { usePrivy, WalletWithMetadata } from "@privy-io/react-auth";
 import { Address, formatEther } from "viem";
 import FundButton, { FundButtonProps } from "./fund-button";
-import { Body, formatBalance } from "@breadcoop/ui";
+import { Body } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
 import { usePublicClient } from "wagmi";
 import { clientEnv } from "@/lib/env";
 import { useModal } from "../../context";
@@ -39,7 +40,7 @@ const FundWithConnectedWalletContent = ({
         const balance = await publicClient.getBalance({
           address: walletAddress,
         });
-        setXDaiBalance(formatBalance(parseFloat(formatEther(balance))));
+        setXDaiBalance(formatAmount(parseFloat(formatEther(balance))));
       } catch {
         void 0;
       }

--- a/src/components/modal/modals/fund-wallet/stacks-balance.tsx
+++ b/src/components/modal/modals/fund-wallet/stacks-balance.tsx
@@ -1,4 +1,5 @@
-import { Body, formatBalance, useBreadBalance } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
+import { Body, useBreadBalance } from "@breadcoop/ui";
 import { Address } from "viem";
 
 const StacksBalance = ({ address }: { address: Address }) => {
@@ -6,7 +7,7 @@ const StacksBalance = ({ address }: { address: Address }) => {
 
   return (
     <Body className="text-surface-grey text-xs">
-      Stacks account Balance: ${formatBalance(parseFloat(BREAD))}
+      Stacks account Balance: ${formatAmount(parseFloat(BREAD))}
     </Body>
   );
 };

--- a/src/components/modal/modals/new-user-onboarding.tsx
+++ b/src/components/modal/modals/new-user-onboarding.tsx
@@ -5,7 +5,6 @@ import { ModalContainer } from "../components";
 import { NewUserOnboardingModalState, useModal } from "../context";
 import {
   Body,
-  formatBalance,
   Heading3,
   Logo,
   useBreadBalance,
@@ -22,6 +21,7 @@ import {
 } from "@phosphor-icons/react";
 import { Address } from "viem";
 import { formatAddress } from "@/utils/address";
+import { formatAmount } from "@/utils/format-amount";
 import Alert from "@/components/alert";
 import Link from "next/link";
 import LocalButton from "@/components/button";
@@ -34,14 +34,14 @@ function BreadBalance({ address }: { address: Address }) {
     <>
       <div className="flex items-center justify-center gap-2">
         <span className="font-breadDisplay text-[3rem] font-black leading-9 text-surface-ink">
-          {formatBalance(parseFloat(BREAD))}
+          {formatAmount(parseFloat(BREAD))}
         </span>
         <span className="bg-paper-main p-1">
           <Logo size={24} variant="square" text="BREAD" />
         </span>
       </div>
       <Body className="text-xs text-surface-grey">
-        ${formatBalance(parseFloat(BREAD))} USD
+        ${formatAmount(parseFloat(BREAD))} USD
       </Body>
     </>
   );

--- a/src/components/modal/modals/stack-result.tsx
+++ b/src/components/modal/modals/stack-result.tsx
@@ -7,7 +7,7 @@ import {
   StackInitSuccessModalState,
   useModal,
 } from "../context";
-import { Body, formatBalance, Heading2, Heading3 } from "@breadcoop/ui";
+import { Body, Heading2, Heading3 } from "@breadcoop/ui";
 import PendingInviteLink from "@/components/pending-invite-link";
 import {
   Accordion,
@@ -23,6 +23,7 @@ import { savingCirclesAbi } from "../../../lib/abis/saving-circles";
 import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "../../../lib/constants";
 import { usePrivy, useSignTypedData } from "@privy-io/react-auth";
 import { getDefaultChainId } from "@/utils/chain";
+import { formatAmount } from "@/utils/format-amount";
 import { shortenUrl } from "@/utils/shorten";
 import { SupabaseInviteLink } from "@/lib/supabase";
 import { useBlockTimestamp } from "@/hooks/use-block-timestamp";
@@ -162,7 +163,8 @@ export const StackSuccessResultModal = ({
           modalState.circle.name,
           modalState.circle.members,
           modalState.circle.duration,
-          formatBalance(modalState.circle.deposit, 2)
+          // Raw, not formatted: the join page parses this back into a number.
+          String(modalState.circle.deposit)
         );
 
         supabaseInviteLinks.push({ long: url, short: "", used: false });
@@ -302,11 +304,11 @@ export const StackSuccessResultModal = ({
                 <RowDetail label="Duration" body={modalState.circle.duration} />
                 <RowDetail
                   label="Est. Deposit amount"
-                  body={`$${formatBalance(modalState.circle.deposit, 2)}`}
+                  body={`$${formatAmount(modalState.circle.deposit, 2)}`}
                 />
                 <RowDetail
                   label="Stack goal"
-                  body={`$${formatBalance(modalState.circle.total, 2)}`}
+                  body={`$${formatAmount(modalState.circle.total, 2)}`}
                 />
               </div>
             </AccordionContent>

--- a/src/components/modal/modals/wallet-funding-status.tsx
+++ b/src/components/modal/modals/wallet-funding-status.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import {
-  Body,
-  formatBalance,
-  Heading2,
-  Logo,
-  useConnectedUser,
-} from "@breadcoop/ui";
+import { Body, Heading2, Logo, useConnectedUser } from "@breadcoop/ui";
+import { formatAmount } from "@/utils/format-amount";
 import { useState } from "react";
 import { ModalContainer, ModalHeader, ModalStatus } from "../components";
 import { useModal, WalletFundingStatusModalState } from "../context";
@@ -53,7 +48,7 @@ const WalletFundingStatusModal = ({
 
   const displayedAmount =
     modalState.status === "success"
-      ? formatBalance(+modalState.breadAmount)
+      ? formatAmount(+modalState.breadAmount)
       : "";
 
   return (

--- a/src/components/modal/modals/withdraw-bread.tsx
+++ b/src/components/modal/modals/withdraw-bread.tsx
@@ -8,11 +8,11 @@ import NumericInput from "@/components/numeric-input";
 import {
   Body,
   formatBalance,
-  FormattedDecimalNumber,
   Logo,
   TUserConnected,
   useConnectedUser,
 } from "@breadcoop/ui";
+import { FormattedDecimalNumber } from "@/components/bread-ui-kit/formatted-decimal-number";
 import { useAccount, useReadContract } from "wagmi";
 import { Address, erc20Abi, isAddress } from "viem";
 import LocalButton from "@/components/button";
@@ -21,6 +21,7 @@ import BreadInfoNote from "@/components/bread-info-note";
 import { cn } from "@/lib/utils";
 import { BREAD_TOKEN_ADDRESS } from "@/lib/constants";
 import { getDefaultChainId } from "@/utils/chain";
+import { formatAmount } from "@/utils/format-amount";
 import { CircularProgressIcon } from "@/components/icons/circular-progress";
 import { ArrowDownIcon } from "@phosphor-icons/react";
 import { useModal } from "../context";
@@ -104,6 +105,7 @@ const WithdrawBreadModal = () => {
     },
   });
 
+  // Not millified: the Max button writes this string back into the amount input.
   const balance = data
     ? formatBalance(Number(data) / 10 ** BREAD_DECIMALS, 2)
     : 0;
@@ -249,7 +251,7 @@ const WithdrawBreadModal = () => {
             </div>
             <div className="flex items-center justify-between mt-2 text-surface-grey">
               <Body className="text-xs">
-                ${formatBalance(Number(form.amount || 0), 2)}
+                ${formatAmount(Number(form.amount || 0), 2)}
               </Body>
               <Body className="text-xs flex items-center justify-end">
                 Balance:{" "}

--- a/src/components/stack.tsx
+++ b/src/components/stack.tsx
@@ -1,4 +1,5 @@
-import { Body, Heading3, Chip, formatBalance } from "@breadcoop/ui";
+import { Body, Heading3, Chip } from "@breadcoop/ui";
+import { millify } from "@/utils/format-amount";
 import { UsersIcon } from "./icons/users";
 import { CoinIcon, CoinsIcon } from "./icons/coin";
 import { CalendarIcon } from "./icons/calendar";
@@ -93,19 +94,19 @@ const Stack = ({
       className: "",
     },
     {
-      label: `Deposit: $${formatBalance(Number(depositAmount), 2)} ${
+      label: `Deposit: $${millify(Number(depositAmount), 2)} ${
         parseCircleIntervalToDate(stack.depositInterval).label
       }`,
       icon: <CoinsIcon />,
       className: "",
     },
     {
-      label: `Pay out: $${formatBalance(Number(depositAmount) * stack.totalMember, 2)} per member`,
+      label: `Pay out: $${millify(Number(depositAmount) * stack.totalMember, 2)} per member`,
       icon: <CoinIcon />,
       className: "",
     },
     {
-      label: `Stack volume: $${formatBalance(totalGoal, 2)}`,
+      label: `Stack volume: $${millify(totalGoal, 2)}`,
       icon: <CalendarIcon />,
       className: "",
     },
@@ -184,10 +185,10 @@ const Stack = ({
               fundsDeposited.isLoading ? (
                 <span className="text-surface-grey text-sm">loading...</span>
               ) : (
-                <>${formatBalance(totalDeposited, 2)}</>
+                <>${millify(totalDeposited, 2)}</>
               )
             ) : (
-              <>${formatBalance(totalDeposited, 2)}</>
+              <>${millify(totalDeposited, 2)}</>
             )}
           </p>
           <Body className="flex items-center justify-start gap-1 text-surface-grey">

--- a/src/components/start-circle-button.tsx
+++ b/src/components/start-circle-button.tsx
@@ -8,6 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import Loading from "@/app/loading";
 import { useSavingCirclesTx } from "@/hooks/use-saving-circles-tx";
 import { parseContractError } from "@/utils/parse-contract-error";
+import { formatAmount } from "@/utils/format-amount";
 import { useModal } from "./modal/context";
 
 interface StartCircleButtonProps extends Omit<ButtonProps, "children"> {
@@ -84,7 +85,7 @@ const StartCircleButton = ({
             <Loading />
           </span>
         ) : (
-          <>Start Stacks - {formatEther(amount)} BREAD</>
+          <>Start Stacks - {formatAmount(+formatEther(amount))} BREAD</>
         )}
       </LocalButton>
     </div>

--- a/src/utils/amount-size.ts
+++ b/src/utils/amount-size.ts
@@ -1,0 +1,24 @@
+/**
+ * Display size step for an amount, so long figures shrink instead of
+ * overflowing their container.
+ *
+ * The step is driven by digits left of the decimal point, since that is what
+ * grows: "$999.00" and "$50,000.00" are three glyphs apart at the same font
+ * size. Each caller maps the step to its own classes, because a hero number
+ * and a card total start from very different sizes.
+ *
+ *   base  up to 9,999
+ *   sm    10,000 – 999,999
+ *   xs    1,000,000 and above
+ */
+export type AmountSizeStep = "base" | "sm" | "xs";
+
+export function amountSizeStep(value: number): AmountSizeStep {
+  const digits = Number.isFinite(value)
+    ? Math.abs(Math.trunc(value)).toString().length
+    : 1;
+
+  if (digits <= 4) return "base";
+  if (digits <= 6) return "sm";
+  return "xs";
+}

--- a/src/utils/format-amount.ts
+++ b/src/utils/format-amount.ts
@@ -1,0 +1,62 @@
+/** Amounts at or above this are rendered with a compact unit (10.5K, 1.25M). */
+const COMPACT_THRESHOLD = 10_000;
+
+// Building an Intl.NumberFormat is far more expensive than formatting with one,
+// so instances are created once per (notation, decimals) pair and reused.
+const formatters = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(compact: boolean, decimals: number) {
+  const key = `${compact ? "c" : "e"}${decimals}`;
+  let formatter = formatters.get(key);
+
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(
+      "en-US",
+      compact
+        ? {
+            notation: "compact",
+            compactDisplay: "short",
+            maximumFractionDigits: decimals,
+          }
+        : {
+            minimumFractionDigits: decimals,
+            maximumFractionDigits: decimals,
+            minimumIntegerDigits: 1,
+            useGrouping: true,
+          }
+    );
+    formatters.set(key, formatter);
+  }
+
+  return formatter;
+}
+
+/**
+ * Formats a number in full: exact and grouped, always ("50,000.00").
+ *
+ * The default for amounts a user reads, reviews or acts on — stack details,
+ * modals, transaction buttons.
+ *
+ * Non-finite input (NaN from an empty form field, Infinity from a division)
+ * formats as zero.
+ */
+export function formatAmount(value: number, decimals = 2): string {
+  return getFormatter(false, decimals).format(
+    Number.isFinite(value) ? value : 0
+  );
+}
+
+/**
+ * Formats a number compactly once it reaches 10K ("50k", "1.25m"), and exactly
+ * below that ("1,250.00").
+ *
+ * For space-constrained summaries only — stack cards and account totals. Use
+ * {@link formatAmount} anywhere the exact figure matters.
+ */
+export function millify(value: number, decimals = 2): string {
+  if (!Number.isFinite(value) || Math.abs(value) < COMPACT_THRESHOLD)
+    return formatAmount(value, decimals);
+
+  // Intl emits an uppercase unit ("50K"); the design calls for "50k".
+  return getFormatter(true, decimals).format(value).toLowerCase();
+}


### PR DESCRIPTION
Amounts were formatted with @breadcoop/ui's formatBalance, which always prints every digit, so a large pool balance or stack volume overflowed its line. Add src/utils/millify.ts: exact and grouped below 10K ("1,250.00"), compact above it ("10.5K", "1.25M", "3.4B"). Intl.NumberFormat construction is the expensive part, so instances are cached per (notation, decimals) pair and reused; non-finite input formats as zero.

Applied to every display-only amount, plus four spots that were rendering raw formatEther output and could leak an 18-decimal string. Two call sites keep formatBalance and say why in a comment: the withdraw Max button writes its string back into the amount input, and stack-result embeds its value in the invite URL.

That invite URL was the second bug: the deposit went in through formatBalance, so it arrived as "90,999,999.00" and Number() read it as NaN — the join page showed $NaN before this change and $0.00 after. Write it raw, and strip commas when parsing so links already in the wild still render.

FormattedDecimalNumber is forked into bread-ui-kit so it can millify too. Its shrunk span de-emphasises cents, so it now only splits exact amounts: in "10.5K" the .5 is magnitude, and shrinking it would read as "$10".