### PR TITLE
docs: rewrite local setup guide and fix time-travel commands

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -40,6 +40,9 @@ NEXT_PUBLIC_PRIVY_CLIENT_ID=
 # https://supabase.com/dashboard/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Server-only: bypasses RLS, used by src/app/api/** and make reset-supabase.
+# Never expose this to the browser.
+SUPABASE_SERVICE_ROLE_KEY=
 
 # Sepolia
 NEXT_PUBLIC_SEPOLIA_RPC_URL=

--- a/README.md
+++ b/README.md
@@ -1,91 +1,237 @@
-# Saving Circles dApp
+# Saving Circles dApp (App-Stacks)
 
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+A web app for saving money together with friends and family — a rotating savings circle
+("stack"). Members deposit a fixed amount each round, and one member claims the pooled
+funds per round until everyone has been paid.
+
+Two halves make up the system:
+
+- **On-chain** — audited Solidity contracts (Saving Circles) hold the money and the rules.
+- **Off-chain** — a [Next.js](https://nextjs.org) frontend plus [Supabase](https://supabase.com)
+  (Postgres), which stores things that don't belong on a public chain: stack names, invite
+  links, and profiles.
+
+**Which path are you on?**
+
+- **Know Next.js and/or Foundry?** → [Quick start](#quick-start) — the commands and the
+  five things you can't guess. Skip everything after it unless something breaks.
+- **New to one or both?** → [Setup](#setup) — the same steps, explained, no assumed
+  knowledge. You don't need to write Solidity or React to run this.
+
+For architecture and code conventions, see [AGENTS.md](./AGENTS.md),
+[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md), and [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+---
+
+## Quick start
+
+Needs Node 22+, pnpm 11, Foundry, jq, and the Supabase CLI.
+
+```bash
+git clone https://github.com/BreadchainCoop/app-stacks.git && cd app-stacks
+make update-contract-submodules   # contracts are a git submodule
+pnpm install
+cp .env.local.example .env.local  # fill it in — see the gotchas below
+pnpm db:push:local                # a fresh Supabase project has no tables
+
+make anvil                        # terminal 1: Gnosis fork, chain 31337, :8545
+make start-local                  # terminal 2: wipe off-chain data, deploy, run dev
+```
+
+Then open **`http://localhost:3001`**, log in with Privy, and fund the embedded wallet it
+creates: `make fund-wallet 0xYourAddress` (100 test ETH + 100 BREAD).
+
+**The five things you can't guess:**
+
+1. **The dev server is on `:3001`**, not `:3000`.
+2. **Set `NEXT_PUBLIC_NODE_ENV=local` and `NEXT_PUBLIC_CHAIN_ID=31337`.** Without the
+   first, `make start-local` aborts on its Supabase-wipe step and every feature flag stays
+   off. Leave the contract addresses blank — `make deploy` writes them.
+3. **Six third-party accounts are mandatory**, not optional: Supabase, Privy,
+   WalletConnect, Alchemy, Upstash Redis, spoo.me. The Zod schemas in `src/lib/env.ts` and
+   `src/lib/envs/server.ts` throw at boot on any missing key. See
+   [Third-party accounts](#third-party-accounts).
+4. **`SUPABASE_DB_URL_LOCAL` must use the session pooler (port `5432`).** Port `6543` fails
+   with `prepared statement "..." already exists`.
+5. **The chain clock only moves forward.** `make time-increase SECONDS=86400` to advance;
+   `make warp` needs a _future_ timestamp because the fork starts at the real present.
+   `make anvil-reset` rewinds. See [Time manipulation](#time-manipulation-for-testing).
+
+Everything below is the same ground at a slower pace, plus
+[Make commands](#useful-make-commands) and [Troubleshooting](#troubleshooting).
+
+---
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18 or higher)
-- [Foundry](https://book.getfoundry.sh/getting-started/installation) (for smart contract development)
-- [Git](https://git-scm.com/)
-- A Web3 wallet (e.g., MetaMask) for testing
+### Command-line tools
 
-## Local Development Setup
+| Tool                                                                 | Why it's needed                                                             |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [Node.js](https://nodejs.org/) v22+                                  | Runs the frontend                                                           |
+| [pnpm](https://pnpm.io/installation) 11                              | Package manager. **Do not use npm or yarn** — this repo pins pnpm settings  |
+| [Foundry](https://book.getfoundry.sh/getting-started/installation)   | Provides `anvil` (local blockchain), `forge` (compile/deploy), `cast` (RPC) |
+| [Git](https://git-scm.com/)                                          | Contracts are pulled in as git submodules                                   |
+| [jq](https://jqlang.github.io/jq/download/)                          | The Makefile reads deployed contract addresses out of JSON with it          |
+| [Supabase CLI](https://supabase.com/docs/guides/cli/getting-started) | Creates the database tables (`brew install supabase/tap/supabase`)          |
 
-### 1. Clone and Initialize
+Quick check that everything resolves:
 
 ```bash
-# Clone the repository
-git clone <your-repo-url>
-cd <your-repo-name>
+node -v && pnpm -v && forge --version && cast --version && jq --version && supabase --version
+```
 
-# Update contract submodules
+### Third-party accounts
+
+The app reads configuration from `.env.local`, and it will refuse to start if required
+values are missing — the env schemas in `src/lib/env.ts` (browser) and
+`src/lib/envs/server.ts` (server) validate them at boot. All of these have free tiers:
+
+| Service                                       | What it does here                          | Values you'll copy                                       |
+| --------------------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
+| [Supabase](https://supabase.com/dashboard)    | Postgres database for off-chain data       | project URL, `anon` key, `service_role` key, DB password |
+| [Privy](https://dashboard.privy.io/)          | Login + gives each user an embedded wallet | app ID, client ID                                        |
+| [WalletConnect](https://dashboard.reown.com/) | Lets external wallets connect              | project ID                                               |
+| [Alchemy](https://www.alchemy.com/)           | Ethereum mainnet reads (token prices, ENS) | API key                                                  |
+| [Upstash Redis](https://console.upstash.com/) | Caches shortened invite links              | REST URL, REST token                                     |
+| [spoo.me](https://spoo.me/)                   | Shortens invite links                      | API token                                                |
+
+> A **wallet** is the account that signs blockchain transactions. Privy creates one for
+> each user automatically ("embedded wallet") after they log in with email, so you don't
+> need MetaMask to click through the app — see
+> [Getting a funded wallet](#7-getting-a-funded-wallet).
+
+---
+
+## Setup
+
+The [Quick start](#quick-start) commands again, one at a time and with the reasoning spelled
+out. Follow it top to bottom — no Solidity or React knowledge assumed, and jargon is
+explained the first time it appears.
+
+### 1. Clone and pull the contracts
+
+The Solidity contracts live in a separate repository, wired in as a git submodule. Without
+this step `contracts/lib/` is empty and deployment fails.
+
+```bash
+git clone https://github.com/BreadchainCoop/app-stacks.git
+cd app-stacks
 make update-contract-submodules
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 pnpm install
 ```
 
-### 3. Environment Setup
+> Installs can look stalled: `pnpm-workspace.yaml` sets `minimumReleaseAge` to 10 days, so
+> pnpm deliberately ignores packages published very recently.
 
-Create a `.env.local` file in the root directory:
+### 3. Create your env file
 
 ```bash
-cp .env.example .env.local
+cp .env.local.example .env.local
 ```
 
-### 4. Start Local Blockchain
+Open `.env.local` and fill in the keys from the [accounts above](#third-party-accounts).
+Two entries need specific values for local development:
 
-In a separate terminal, start Anvil (local Ethereum node):
+```bash
+NEXT_PUBLIC_NODE_ENV=local   # unlocks every feature flag; also required by make reset-supabase
+NEXT_PUBLIC_CHAIN_ID=31337   # the local Anvil chain
+```
+
+Leave the contract addresses and `NEXT_PUBLIC_SAVING_CIRCLES_CONTRACT_CREATION_BLOCK`
+blank — `make deploy` fills those in for you in step 5.
+
+`SUPABASE_DB_URL_LOCAL` is your Supabase connection string, used only for database
+migrations. Take it from **Dashboard → Settings → Database → Connection string → URI**, and
+use the **session pooler** (port `5432`); the transaction pooler on port `6543` fails with
+`prepared statement "..." already exists`.
+
+### 4. Create the database tables
+
+A fresh Supabase project is empty. Apply the migrations in `supabase/migrations/`:
+
+```bash
+pnpm db:push:local
+```
+
+This connects straight to the database with `SUPABASE_DB_URL_LOCAL`, so `supabase login`
+isn't needed. More detail, including how to add a migration, is in
+[`supabase/README.md`](./supabase/README.md).
+
+### 5. Start the local blockchain
+
+**Anvil** is a blockchain that runs on your machine. This repo runs it as a _fork_ of
+Gnosis Chain — it copies real Gnosis state on demand, so real tokens exist, but nothing you
+do leaves your laptop and no real money is involved.
+
+In its own terminal:
 
 ```bash
 make anvil
 ```
 
-This will:
+This forks Gnosis at the latest block on `http://localhost:8545`, with chain ID `31337`,
+mining a block every 5 seconds. **Leave this terminal running** for the whole session.
 
-- Fork Gnosis Chain at the latest block
-- Run on `http://localhost:8545`
-- Use chain ID `31337`
-- Mine blocks every 5 seconds
+### 6. Deploy the contracts and start the app
 
-**Keep this terminal running** throughout your development session.
-
-### 5. Deploy Contracts
-
-In another terminal, deploy the smart contracts and start the development server:
+In a second terminal:
 
 ```bash
 make start-local
 ```
 
-This will:
+Which, in order:
 
-- Clear off-chain stack data in Supabase (`user_stacks`, `stacks_metadata`) so local dev starts from a clean slate — only runs when `NEXT_PUBLIC_NODE_ENV=local`
-- Compile and deploy the contracts to your local Anvil instance
-- Automatically update your `.env.local` with the deployed contract addresses
-- Start the Next.js development server
+1. Wipes off-chain stack data in Supabase (`user_stacks`, `stacks_metadata`) for a clean
+   slate — this refuses to run unless `NEXT_PUBLIC_NODE_ENV=local`, so it can never hit a
+   shared database
+2. Clears previous build output (`contracts/broadcast`, `cache`, `out`)
+3. Compiles and deploys the contracts to your Anvil node
+4. Writes the deployed addresses and creation block into your `.env.local`
+5. Starts the Next.js dev server
 
-**Default deployer account**: `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` (Anvil's first account)
+Open **[http://localhost:3001](http://localhost:3001)** (note: `3001`, not `3000`).
 
-### 6. Configure MetaMask
+**Default deployer account:** `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` — Anvil's first
+account, which starts with test funds and owns the deployed contracts.
 
-Add the local network to MetaMask:
+### 7. Getting a funded wallet
+
+Log in through Privy in the browser. The embedded wallet it creates starts empty, so top it
+up with test funds — copy your address from the app, then:
+
+```bash
+make fund-wallet 0xYourWalletAddress
+```
+
+You now have 100 test ETH (for transaction fees) and 100 test BREAD (the token stacks save
+in). See [Funding a wallet](#funding-a-wallet) for the full options.
+
+<details>
+<summary>Optional: using MetaMask or another external wallet instead</summary>
+
+Add the local network manually:
 
 - **Network Name**: Anvil Local
 - **RPC URL**: `http://localhost:8545`
 - **Chain ID**: `31337`
 - **Currency Symbol**: `ETH`
 
-Import the default Anvil account for testing:
+To import Anvil's pre-funded first account, use private key
+`0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`.
 
-- **Private Key**: `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+⚠️ This key is public knowledge and hard-coded in every Foundry install. **Never send real
+funds to it or use it on a real network.**
 
-⚠️ **Never use this account on mainnet or with real funds!**
+</details>
 
-Open [http://localhost:3000](http://localhost:3000) to see your dApp.
+---
 
 ## Development Workflow
 
@@ -107,11 +253,14 @@ If you need a fresh state:
 make anvil-reset
 ```
 
-Then redeploy:
+This also rewinds the clock back to the real current time (see
+[Time manipulation](#time-manipulation-for-testing)). Then redeploy:
 
 ```bash
 make start-local
 ```
+
+If transactions afterwards fail with nonce errors, run `make reset-nonces`.
 
 ### Funding a Wallet
 
@@ -133,54 +282,84 @@ make fund-wallet 0xYourWalletAddress bread=200
 
 `eth=` and `bread=` are mutually exclusive — pass neither to fund both with the defaults. The command prints the resulting ETH and BREAD balances for each address once complete.
 
+Requires a deployment to exist, since it reads the BREAD address from
+`contracts/out/SAVING_CIRCLES_DEPLOYMENT.json`.
+
 ### Time Manipulation (for testing)
 
-Use the Makefile commands to manipulate Anvil's block timestamp directly — no system clock changes needed.
+Stacks run on rounds that can be days or weeks long. Rather than waiting, move the _chain's_
+clock — the Makefile commands below do this via Anvil's RPC. Your system clock is untouched.
 
-**To jump to a specific timestamp:**
-
-```bash
-make warp TIMESTAMP=1735689600   # January 1, 2025 00:00:00 UTC
-```
-
-**To advance time by a number of seconds:**
+**Advance by a number of seconds** — the one you'll normally want:
 
 ```bash
-make time-increase SECONDS=86400   # advance by 1 day
+make time-increase SECONDS=86400    # advance by 1 day
+make time-increase SECONDS=604800   # advance by 1 week
 ```
 
-> ⚠️ **Important:** Anvil's clock only moves forward. Once a block has been mined at a given timestamp, you cannot go back to an earlier one. To start fresh, restart Anvil with `make anvil-reset`.
+**Jump to a specific timestamp:**
+
+```bash
+make warp TIMESTAMP=$(($(date +%s) + 86400))   # 1 day from now
+```
+
+> ⚠️ **The chain clock only moves forward.** `warp` to a timestamp earlier than the current
+> block fails with `Timestamp error: ... is lower than previous block's timestamp`. Because
+> `make anvil` forks Gnosis at its _latest_ block, the chain starts at the real present —
+> so any fixed past date is rejected. Compute the target relative to now, as above.
+
+**Inspecting and resetting:**
+
+```bash
+make timestamp   # print the current block timestamp
+make mine        # mine a single block
+make time-reset  # pull the chain clock back to your system clock
+```
+
+`make time-reset` only succeeds when the chain is _behind_ your system clock — i.e. right
+after `make anvil-reset`. Once you've advanced time it fails, by the same forward-only rule.
+To get back to real time, use `make anvil-reset`.
 
 **Typical workflow for time-based testing:**
 
-1. `make time-increase SECONDS=2592000` to jump 30 days ahead
-2. Interact with contracts as needed
-3. Advance further with another `make time-increase` or jump to a precise moment with `make warp`
+1. Create a stack with a short deposit interval (e.g. 5 minutes) and make deposits
+2. `make time-increase SECONDS=2592000` to jump 30 days ahead
+3. Reload the app and confirm the round has advanced
+4. Advance further with another `make time-increase`
 
-```bash
-make mine                          # Mine a single block
-make timestamp                     # Show current block timestamp
-make time-increase SECONDS=86400   # Advance time by 1 day
-make warp TIMESTAMP=1735689600     # Jump to a specific timestamp (January 1, 2025 00:00:00 UTC)
-```
+---
 
 ## Useful Make Commands
 
-| Command                                | Description                                       |
-| -------------------------------------- | ------------------------------------------------- |
-| `make anvil`                           | Start local blockchain (Gnosis fork)              |
-| `make start-local`                     | Clear off-chain data, deploy contracts, start dev |
-| `make deploy`                          | Deploy contracts and update .env.local            |
-| `make reset-supabase`                  | Wipe off-chain stack data (local env only)        |
-| `make anvil-reset`                     | Reset blockchain to fresh state                   |
-| `make update-contract-submodules`      | Update contract dependencies                      |
-| `make fund-wallet 0xAddr [0xAddr ...]` | Fund one or more wallets with ETH and BREAD       |
-| `make fund-wallet 0xAddr eth=N`        | Fund the wallet(s) with N ETH only                |
-| `make fund-wallet 0xAddr bread=N`      | Fund the wallet(s) with N BREAD only              |
-| `make mine`                            | Mine a single block                               |
-| `make timestamp`                       | Show current block timestamp                      |
-| `make time-increase SECONDS=N`         | Advance Anvil time by N seconds                   |
-| `make warp TIMESTAMP=N`                | Set Anvil time to a specific timestamp            |
+| Command                                | Description                                          |
+| -------------------------------------- | ---------------------------------------------------- |
+| `make anvil`                           | Start local blockchain (Gnosis fork)                 |
+| `make start-local`                     | Clear off-chain data, deploy contracts, start dev    |
+| `make deploy`                          | Deploy contracts and update .env.local               |
+| `make update-env`                      | Re-read deployed addresses into .env.local           |
+| `make reset-supabase`                  | Wipe off-chain stack data (local env only)           |
+| `make anvil-reset`                     | Reset blockchain and clock to fresh state            |
+| `make reset-nonces`                    | Reset nonces for all Anvil accounts                  |
+| `make update-contract-submodules`      | Update contract dependencies                         |
+| `make install-contract-deps`           | `forge install` inside `contracts/`                  |
+| `make fund-wallet 0xAddr [0xAddr ...]` | Fund one or more wallets with ETH and BREAD          |
+| `make fund-wallet 0xAddr eth=N`        | Fund the wallet(s) with N ETH only                   |
+| `make fund-wallet 0xAddr bread=N`      | Fund the wallet(s) with N BREAD only                 |
+| `make mine`                            | Mine a single block                                  |
+| `make timestamp`                       | Show current block timestamp                         |
+| `make time-increase SECONDS=N`         | Advance Anvil time by N seconds                      |
+| `make warp TIMESTAMP=N`                | Set Anvil time to a specific timestamp (future only) |
+| `make time-reset`                      | Reset chain clock to system time (only if behind)    |
+
+## Useful pnpm Commands
+
+| Command              | Description                                     |
+| -------------------- | ----------------------------------------------- |
+| `pnpm dev`           | Dev server on `http://localhost:3001`           |
+| `pnpm build`         | Production build — also the full type-check     |
+| `pnpm lint`          | ESLint                                          |
+| `pnpm format`        | Prettier write (`format:check` to verify only)  |
+| `pnpm db:push:local` | Apply Supabase migrations to your local project |
 
 ## Custom Deployment
 
@@ -194,6 +373,12 @@ make deploy \
 ```
 
 ## Troubleshooting
+
+### `___ Provide all CLIENT env variables ___` / `___ Provide all SERVER env variables ___`
+
+A required entry in `.env.local` is missing or empty. The error lists the offending keys.
+Client-side keys are validated in `src/lib/env.ts`, server-side ones in
+`src/lib/envs/server.ts`. Restart the dev server after editing `.env.local`.
 
 ### Contract addresses not updating
 
@@ -209,20 +394,39 @@ Then run:
 make update-env
 ```
 
+### `Error: contracts/out/SAVING_CIRCLES_DEPLOYMENT.json not found`
+
+Nothing has been deployed yet in this session. Ensure `make anvil` is running in another
+terminal, then run `make deploy`.
+
 ### Nonce issues after reset
 
-If transactions fail with nonce errors after `anvil-reset`, restart MetaMask or clear its activity data for the local network.
+If transactions fail with nonce errors after `anvil-reset`, run `make reset-nonces`. For
+external wallets, also restart MetaMask or clear its activity data for the local network.
+
+### `reset-supabase` refuses to run
+
+It requires `NEXT_PUBLIC_NODE_ENV=local` in `.env.local`, plus
+`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`. This guard is intentional — it
+stops the command from wiping a shared database.
+
+### Migration push fails
+
+`prepared statement "..." already exists` means `SUPABASE_DB_URL_LOCAL` points at the
+transaction pooler (port `6543`); switch it to the session pooler (`5432`).
+`Remote migration versions not found in local migrations directory` means the database has
+migrations applied that your branch doesn't contain — usually another branch pushed to the
+same project. Pull/merge that branch rather than running the suggested `migration repair`,
+which would leave the recorded history disagreeing with the real schema.
 
 ### Port already in use
 
-If port 8545 or 3000 is already in use:
-
 ```bash
-# For Anvil, stop the existing process
+# For Anvil (8545), stop the existing process
 lsof -ti:8545 | xargs kill -9
 
 # For Next.js, use a different port
-npm run dev -- -p 3001
+pnpm dev -- -p 3002
 ```
 
 ## Learn More
@@ -230,3 +434,4 @@ npm run dev -- -p 3001
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Foundry Book](https://book.getfoundry.sh/)
 - [Anvil Documentation](https://book.getfoundry.sh/anvil/)
+- [Supabase Documentation](https://supabase.com/docs)


### PR DESCRIPTION
Reorganise the README around two paths: a Quick start for developers who already know Next.js or Foundry, and the existing step-by-step Setup for everyone else. Both cover the same ground.

Correct several instructions that could not work:

- `make warp TIMESTAMP=1735689600` (Jan 1 2025) always failed. `make anvil` forks Gnosis at its latest block, so the chain starts at the real present and any past timestamp is rejected by Anvil's forward-only clock. Replaced with a now-relative example. Verified against a live fork, along with `mine`, `timestamp`, `time-increase`, `warp` and `anvil-reset`.
- `cp .env.example .env.local` named a file that does not exist.
- The dev server runs on port 3001, not 3000, and the troubleshooting section suggested npm rather than pnpm.
- Node.js v18 -> v22+, matching CONTRIBUTING.md.

Document `make time-reset`, which only succeeds while the chain clock is behind the system clock, i.e. immediately after `make anvil-reset`.

Fill in what a first-time setup was missing: pnpm, jq and the Supabase CLI as prerequisites; the six third-party accounts whose keys the env schemas require at boot; applying the Supabase migrations, without which the database has no tables; and the `NEXT_PUBLIC_NODE_ENV=local` guard that makes `make start-local` abort.

Add SUPABASE_SERVICE_ROLE_KEY to .env.local.example. It is required by src/lib/envs/server.ts and by `make reset-supabase`, but was absent from the example file, so anyone following the setup hit a wall.