### PR TITLE
feat: enable automatic claims by default on join

### DIFF
--- a/src/app/new/_components/form/overview.tsx
+++ b/src/app/new/_components/form/overview.tsx
@@ -22,6 +22,7 @@ import { sleep } from "@/utils/sleep";
 import { waitForTransactionReceipt } from "@wagmi/core";
 import { wagmiConfig } from "@/components/providers/web3";
 import { useSponsoredTx } from "@/hooks/use-sponsored-tx";
+import { useAutomaticClaims } from "@/hooks/use-automatic-claims";
 import { simulateContract } from "@wagmi/core";
 import { parseContractError } from "@/utils/parse-contract-error";
 import { getIntervalById, splitIntervalId } from "@/utils/deposit-interval";
@@ -47,6 +48,7 @@ const StackOverviewForm = ({ onBack }: { onBack: () => void }) => {
   const total = (members || 0) * (freqDeposit || 0);
   const { user } = useConnectedUser();
   const { sendSponsoredTransaction } = useSponsoredTx();
+  const { activate: enableAutomaticClaims } = useAutomaticClaims();
 
   const createStack = async (data: StackFormSchemaData) => {
     if (form.formState.isSubmitting) return;
@@ -127,6 +129,8 @@ const StackOverviewForm = ({ onBack }: { onBack: () => void }) => {
         name: data.name,
         status: "successful",
       });
+
+      await enableAutomaticClaims(newCircleId, true);
 
       const parsedInterval = splitIntervalId(interval.id);
       const duration = `${data.members * parsedInterval[0]} ${parsedInterval[1]}`;

--- a/src/app/stacks/join/_components/accept-invite.tsx
+++ b/src/app/stacks/join/_components/accept-invite.tsx
@@ -2,6 +2,7 @@
 
 import Loading from "@/app/loading";
 import LocalButton from "@/components/button";
+import { useAutomaticClaims } from "@/hooks/use-automatic-claims";
 import { useSavingCirclesTx } from "@/hooks/use-saving-circles-tx";
 import { savingCirclesAbi } from "@/lib/abis/saving-circles";
 import { SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
@@ -34,6 +35,7 @@ export default function AcceptInvite({
   const router = useRouter();
   const { user } = useConnectedUser();
   const { sendSavingCirclesTx } = useSavingCirclesTx();
+  const { activate: enableAutomaticClaims } = useAutomaticClaims();
   const { user: privyUser } = usePrivy();
   const queryClient = useQueryClient();
 
@@ -105,6 +107,10 @@ export default function AcceptInvite({
       }).catch((error) => {
         console.error("Failed to mark invite as used:", error);
       });
+
+      // Not awaited: the redirect above should not wait on the opt-in tx. The
+      // hook primes the toggle's query cache once it lands.
+      enableAutomaticClaims(parsedId, true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       const contractError =

--- a/src/components/modal/modals/automatic-claims.tsx
+++ b/src/components/modal/modals/automatic-claims.tsx
@@ -24,9 +24,7 @@ const AutomaticClaimsModal = ({
   modalState: AutomaticClaimsModalState;
 }) => {
   const modal = useModal();
-  const { activate, status, setStatus } = useAutomaticClaims(
-    stackId.toString()
-  );
+  const { activate, status, setStatus } = useAutomaticClaims();
 
   const closeModal = () => modal.setModal(null);
   const enabling = !currentValue;
@@ -108,7 +106,9 @@ const AutomaticClaimsModal = ({
               : "By deactivating automatic claims you will need to manually claim your funds when it's your turn."}
           </Body>
           <div className="lifted-button-container">
-            <LocalLiftedButton onClick={() => activate(enabling)}>
+            <LocalLiftedButton
+              onClick={() => activate(BigInt(stackId), enabling)}
+            >
               {enabling ? "Activate" : "Deactivate"} automatic claims
             </LocalLiftedButton>
           </div>

--- a/src/hooks/use-automatic-claims.ts
+++ b/src/hooks/use-automatic-claims.ts
@@ -10,7 +10,14 @@ import { useConnectedUser } from "@breadcoop/ui";
 
 export type AutomaticClaimsStatus = "idle" | "loading" | "success" | "error";
 
-export function useAutomaticClaims(stackId: string) {
+/**
+ * Automatic claims are opt-out: members are enrolled when they join a stack and
+ * can turn it off later from the toggle on the stack page. The contract
+ * defaults to disabled and has no flag for "explicitly set", so joining has to
+ * write the opt-in — defaulting it on read would re-enable it right after a
+ * user opts out.
+ */
+export function useAutomaticClaims() {
   const { sendAutomaticSavingCirclesTx } = useAutomaticSavingCirclesTx();
   const { user: privyUser } = usePrivy();
   const { user } = useConnectedUser();
@@ -18,21 +25,26 @@ export function useAutomaticClaims(stackId: string) {
   const [status, setStatus] = useState<AutomaticClaimsStatus>("idle");
   const queryClient = useQueryClient();
 
-  const activate = async (enabled: boolean) => {
+  const activate = async (circleId: bigint, enabled: boolean) => {
     if (status === "loading" || !privyUser?.id) return;
     setStatus("loading");
 
     try {
       await sendAutomaticSavingCirclesTx({
         functionName: "setAutomaticClaimsEnabled",
-        args: [BigInt(stackId), enabled],
+        args: [circleId, enabled],
       });
+
+      if (!address) {
+        setStatus("success");
+        return;
+      }
 
       const queryKey = readContractQueryKey({
         abi: automaticSavingCirclesAbi,
         address: AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS,
         functionName: "isAutomaticClaimsEnabled",
-        args: [BigInt(stackId), address!],
+        args: [circleId, address],
         chainId: getDefaultChainId(),
       });
 


### PR DESCRIPTION
## What

Automatic claims are now **opt-out**: members are enrolled when they join a stack, and the existing toggle on the stack page is what turns it off.

## Why this shape

The contract's `automaticClaimsEnabled[circleId][member]` mapping defaults to `false` and there is no "has been explicitly set" flag, so on-by-default cannot be a read-side default — it has to be *written* at the moment a member joins. Doing it anywhere else (e.g. on stack-page load) would silently re-enable automatic claims right after a user turned them off.

`setAutomaticClaimsEnabled` has no member/active modifiers, so the write is safe to make immediately after joining, before the circle starts.

## Changes

- **`src/hooks/use-default-automatic-claims.ts`** (new) — sends `setAutomaticClaimsEnabled(circleId, true)`. Sponsored and UI-less like the existing toggle tx. It swallows its own errors so a failed opt-in can never fail the join/create flow, and it primes the `isAutomaticClaimsEnabled` query cache on success so the toggle reads as on without a manual refetch.
- **`src/app/new/_components/form/overview.tsx`** — enrolls the creator after `create` lands and the circle id is parsed from the receipt. Awaited, since the user is parked on the success modal anyway.
- **`src/app/stacks/join/_components/accept-invite.tsx`** — enrolls the invitee after `redeemInvite` succeeds. Deliberately *not* awaited: `development` recently reworked this flow to redirect early, and blocking the redirect on another tx would regress that. The cache priming in the hook covers the toggle state.

## Notes for review

- **Existing members are not retroactively enrolled** — this applies only to stacks created or joined from now on. Backfilling would require each member to sign their own tx, so the app can't do it on their behalf.
- **Automatic deposits are untouched.** The parallel `AutomaticDeposit` toggle still defaults off. Making both opt-out would be consistent, but deposits pull funds rather than push them, so that felt like a separate decision.
- **Toggle copy left as-is** (`Activate Automatic Claims`). It reads a little odd next to a switch that starts on, but `development` restyled this label recently and the deposits toggle uses identical wording — renaming only one would break the pair. Happy to change both in a follow-up.

## Rebase note

Rebased onto `development` after it moved ahead. Two conflicts resolved: the toggle label (took `development`'s restyled version) and the `accept-invite` redeem flow (rebuilt on top of the new early-redirect structure). The original commit also gated the opt-in behind the `automaticClaim` feature flag; `f5da5da` has since removed that flag entirely, so the gate is gone.

## Verification

- `eslint` clean on the changed files; pre-commit hooks (prettier + `next lint`) passed.
- `tsc --noEmit` clean across `src/` after the rebase.
- **Not exercised in the browser** — the create and join flows need a dev server with a funded wallet.