### PR TITLE
feat: hide spam stacks from the public list and block offensive aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "embla-carousel-react": "^8.3.1",
     "jose": "^5.9.6",
     "next": "15.4.10",
+    "obscenity": "^0.4.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.68.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       next:
         specifier: 15.4.10
         version: 15.4.10(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      obscenity:
+        specifier: ^0.4.1
+        version: 0.4.1
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -5782,6 +5785,18 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution:
+      {
+        integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution:
       {
@@ -7529,14 +7544,6 @@ packages:
         integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==,
       }
 
-  jsesc@3.0.2:
-    resolution:
-      {
-        integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==,
-      }
-    engines: { node: ">=6" }
-    hasBin: true
-
   jsesc@3.1.0:
     resolution:
       {
@@ -8400,6 +8407,13 @@ packages:
         integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
       }
     engines: { node: ">= 0.4" }
+
+  obscenity@0.4.1:
+    resolution:
+      {
+        integrity: sha512-hzkBkFsoiOVB1tYCnC3dqh/Y/S+iis0hC6mqexVfg+LRCcVS7GLTcbW14+BuKMNDqPwNJsM7+tCVki7gWq73lw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   ofetch@1.5.1:
     resolution:
@@ -11006,7 +11020,7 @@ snapshots:
       "@babel/types": 7.25.7
       "@jridgewell/gen-mapping": 0.3.5
       "@jridgewell/trace-mapping": 0.3.25
-      jsesc: 3.0.2
+      jsesc: 3.1.0
 
   "@babel/generator@7.29.1":
     dependencies:
@@ -13189,7 +13203,7 @@ snapshots:
   "@react-native/community-cli-plugin@0.85.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)":
     dependencies:
       "@react-native/dev-middleware": 0.85.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      debug: 4.4.3
+      debug: 4.4.0
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -13205,7 +13219,7 @@ snapshots:
   "@react-native/debugger-shell@0.85.2":
     dependencies:
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.0
       fb-dotslash: 0.5.8
     transitivePeerDependencies:
       - supports-color
@@ -13218,7 +13232,7 @@ snapshots:
       chrome-launcher: 0.15.2
       chromium-edge-launcher: 0.3.0
       connect: 3.7.0
-      debug: 4.4.3
+      debug: 4.4.0
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
@@ -17306,6 +17320,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -18429,8 +18447,6 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jsesc@3.0.2: {}
-
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -18701,7 +18717,7 @@ snapshots:
 
   metro-file-map@0.84.3:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.0
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -18796,7 +18812,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.3
+      debug: 4.4.0
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -18998,6 +19014,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obscenity@0.4.1: {}
 
   ofetch@1.5.1:
     dependencies:

--- a/src/constants/blocked-circles.ts
+++ b/src/constants/blocked-circles.ts
@@ -1,0 +1,25 @@
+import { Address } from "viem";
+
+/**
+ * Circles hidden from the public list on the homepage.
+ *
+ * Both lists are maintained by hand. Do not derive them from a circle's
+ * members: `create()` takes the owner from calldata without checking it against
+ * `msg.sender`, so anyone can plant a real user's address on a spam circle.
+ * Expanding a block through membership would let them use that to hide an
+ * innocent user's own circles.
+ */
+export const BLOCKED_CIRCLE_IDS: ReadonlySet<string> = new Set<string>([]);
+
+/**
+ * Lowercased owner addresses. One entry covers every circle that owner created,
+ * which is usually the whole batch from a single spammer.
+ */
+export const BLOCKED_OWNERS: ReadonlySet<string> = new Set<string>([]);
+
+export function isBlockedCircle(id: bigint, owner: Address): boolean {
+  return (
+    BLOCKED_CIRCLE_IDS.has(id.toString()) ||
+    BLOCKED_OWNERS.has(owner.toLowerCase())
+  );
+}

--- a/src/hooks/use-all-circles.ts
+++ b/src/hooks/use-all-circles.ts
@@ -7,6 +7,7 @@ import { formatEther, zeroAddress } from "viem";
 import { getDefaultChainId } from "@/utils/chain";
 import { useBlockTimestamp } from "./use-block-timestamp";
 import { getUserCircleStatus } from "@/lib/get-user-circle-status";
+import { isBlockedCircle } from "@/constants/blocked-circles";
 import { useCirclesState } from "./use-circles-state";
 import { CircleState } from "@/lib/circle-state";
 import { useConnectedUser } from "@breadcoop/ui";
@@ -60,6 +61,21 @@ export function useAllCircles(page: number = 0) {
       }
 
       const circleData = circleResult.result as unknown as UserCircleData;
+
+      if (isBlockedCircle(circleData.circleId, circleData.circleInfo.owner)) {
+        continue;
+      }
+
+      // Spam circles get created and abandoned. An unstarted circle can only be
+      // joined through an owner-signed invite, so it has nothing to offer a
+      // browsing non-member — members still see their own under /account.
+      if (
+        circleData.circleInfo.effectiveCircleStartTime === BigInt(0) &&
+        !circleData.isMember
+      ) {
+        continue;
+      }
+
       const status = getUserCircleStatus({
         circle: circleData,
         now,

--- a/src/lib/alias.ts
+++ b/src/lib/alias.ts
@@ -1,3 +1,9 @@
+import {
+  RegExpMatcher,
+  englishDataset,
+  englishRecommendedTransformers,
+} from "obscenity";
+
 export const ALIAS_MIN_LENGTH = 3;
 export const ALIAS_MAX_LENGTH = 20;
 
@@ -30,10 +36,22 @@ const RESERVED_ALIASES = new Set([
   "stacks",
 ]);
 
+// Built once at module load and reused; matching is stateless.
+const profanityMatcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+});
+
+// Offensive aliases the profanity dataset doesn't recognise on its own. Append
+// as they turn up; matched case-insensitively like RESERVED_ALIASES.
+const BLOCKED_ALIASES = new Set(["poindexter"]);
+
 /**
  * Validates a display alias. Returns an error message, or null when valid.
- * Mirrors the database constraints (format check + reserved list); uniqueness
- * is enforced only by the case-insensitive unique index in Postgres.
+ * Covers the database constraints (format check + reserved list) plus a
+ * profanity check that only lives here — writes reach `profiles` solely through
+ * POST /api/profile, so this is the effective gate. Uniqueness is enforced only
+ * by the case-insensitive unique index in Postgres.
  */
 export function validateAlias(alias: string): string | null {
   if (alias.length < ALIAS_MIN_LENGTH) {
@@ -50,6 +68,13 @@ export function validateAlias(alias: string): string | null {
 
   if (RESERVED_ALIASES.has(alias.toLowerCase())) {
     return "This alias is reserved";
+  }
+
+  if (
+    BLOCKED_ALIASES.has(alias.toLowerCase()) ||
+    profanityMatcher.hasMatch(alias)
+  ) {
+    return "This alias isn't allowed";
   }
 
   return null;


### PR DESCRIPTION
Filters maliciously created stacks out of the public list, and stops offensive aliases from being set. Two unrelated abuse vectors that happened to surface together.

## Why the circle filter looks like this

`SavingCircles.create()` is permissionless, and the homepage carousel enumerates every circle id from `0` to `nextId` — so every spam circle ever created lands on the front page.

Two rules in `useAllCircles`:

1. **A hand-maintained blocklist** of circle ids and owner addresses. Owner is already in `circleInfo`, so blocking by owner costs no extra RPC and one entry usually covers a spammer's whole batch.
2. **Unstarted circles are hidden from non-members.** This is what does the real work — spam circles get created and abandoned, and an unstarted circle can only be joined through an owner-signed invite, so it has nothing to offer someone browsing. The `isMember` exemption matters: the homepage is only `HeroBanner + HomeAllStacks`, with no "my stacks" section, so without it you wouldn't see your own stack anywhere on the homepage until you started it.

**The blocklist is deliberately not derived from a circle's members.** `create()` takes `_circle.owner` from calldata and never checks it against `msg.sender`, so anyone can plant a real user's address as owner of a spam circle. If a block expanded through membership, a spammer could use that to make an innocent user's own circles disappear — they'd control our filter. Deriving the list is also why blocking is applied to the public list only; `useUserCirclesList` is untouched, so nobody loses circles from their own account page.

## Why the alias change looks like this

The offending aliases all passed `validateAlias` cleanly — the existing rules cover format and impersonation (ASCII-only, so no homoglyphs; no URLs possible) but say nothing about profanity.

- `obscenity` handles the bulk. It's zero-dependency, ~27 KB gzipped, and lands in a lazily-loaded chunk — no route's First Load JS changed. It resolved to **0.4.1 rather than latest** because of our `minimumReleaseAge: 864000` policy in `pnpm-workspace.yaml`; that's fine, and 0.4.1 actually catches more of the offending names than 0.4.6 does.
- A short `BLOCKED_ALIASES` set covers what a wordlist can't. One of the names was an insult only in context, not profanity — nothing automated will ever flag that class, so it needs a list a human can append to.

The profanity check lives only in TS, not mirrored into a Postgres CHECK constraint like `RESERVED_ALIASES` is. Writes reach `profiles` solely through `POST /api/profile` (anon/authenticated writes are revoked), so this is the effective gate, and a wordlist in a constraint would mean a migration every time we add a term.

## What this does not do

- **The offensive aliases already in `profiles` are still live.** This only blocks new ones. They render on `/stacks/[id]` and `/account/[address]` until someone with Supabase access nulls them:
  ```sql
  update public.profiles set username = null
  where lower(username::text) in ('fuckface','poindexter','vibecoded_bullshite');
  ```
  `DisplayName` falls back to ENS and then a formatted address, so it degrades cleanly.
- **`BLOCKED_CIRCLE_IDS` and `BLOCKED_OWNERS` ship empty.** The unstarted-circle rule carries the spam side for now; the lists are there to seed once we have specific ids.
- **The `create()` owner hole is not fixed here.** The real fix is `require(_circle.owner == msg.sender)` in the `saving-circles` submodule, which needs an upstream PR and a redeploy, and wouldn't clean up existing circles anyway.
- Filtered pages render fewer than 40 cards, since pagination is driven by `nextId`. Cosmetic.

## Verification

`pnpm lint` clean, `pnpm build` succeeds, `pnpm format:check` clean apart from a pre-existing failure in `.github/ISSUE_TEMPLATE/design.md` that this branch doesn't touch.

`validateAlias` was run directly against the real inputs: all three offending aliases are rejected case-insensitively, while `alex`, `bread_lover`, `assassin` and `analysis` are still accepted (`obscenity` handles the Scunthorpe class correctly), and the existing length/format/reserved rules are unaffected.

The circle filter was **not** verified in a browser — the local env points at chain `31337` with no anvil running, and `make start-local` resets Supabase tables and rewrites `.env.local`, which didn't seem worth it for two `continue` statements. Worth a look on a deployed environment before merge.
