### PR TITLE
feat(members): right-align member status chips

### DIFF
--- a/src/app/stacks/[id]/_components/members-info.tsx
+++ b/src/app/stacks/[id]/_components/members-info.tsx
@@ -127,30 +127,37 @@ const MembersInfo = ({
           return (
             <AccordionItem key={member} value={member}>
               <AccordionHeader>
-                <div className="flex items-center justify-start gap-x-4 gap-y-1 flex-wrap">
+                <div className="flex w-full flex-col items-start gap-1 md:flex-row md:items-center md:justify-between md:gap-x-4 md:gap-y-1">
                   <Body bold>
                     <DisplayName address={member} />
                   </Body>
-                  {member === owner && (
-                    <Chip className="font-bold text-blue-1 bg-paper-main border-current text-xs">
-                      Group owner
-                    </Chip>
-                  )}
-                  {showDepositChips &&
-                    (hasDeposited ? (
-                      <Chip className="font-bold border-current! text-system-green text-xs">
-                        Deposited
+                  {/* Chips stack under the name on mobile (they'd otherwise
+                      overflow the row and clip). From md up they sit
+                      right-aligned; the shared AccordionTrigger adds gap-2.5
+                      (10px) before the chevron, so md:mr-1.5 (6px) brings the
+                      group to 16px from the arrow. */}
+                  <div className="flex flex-wrap items-center gap-2 md:shrink-0 md:justify-end md:mr-1.5">
+                    {member === owner && (
+                      <Chip className="font-bold text-blue-1 bg-paper-main border-current text-xs">
+                        Group owner
                       </Chip>
-                    ) : (
-                      <Chip className="font-bold border-current! text-system-warning text-xs">
-                        Not deposited
+                    )}
+                    {showDepositChips &&
+                      (hasDeposited ? (
+                        <Chip className="font-bold border-current! text-system-green text-xs">
+                          Deposited
+                        </Chip>
+                      ) : (
+                        <Chip className="font-bold border-current! text-system-warning text-xs">
+                          Not deposited
+                        </Chip>
+                      ))}
+                    {claimedByMember[member.toLowerCase()] && (
+                      <Chip className="font-bold border-system-green! bg-system-green! text-paper-main text-xs">
+                        Claimed
                       </Chip>
-                    ))}
-                  {claimedByMember[member.toLowerCase()] && (
-                    <Chip className="font-bold border-system-green! bg-system-green! text-paper-main text-xs">
-                      Claimed
-                    </Chip>
-                  )}
+                    )}
+                  </div>
                 </div>
               </AccordionHeader>
               <AccordionContent>


### PR DESCRIPTION
Right-aligns the per-member status chips in the stack details member accordions.

Follow-up to [#158](https://github.com/BreadchainCoop/app-stacks/pull/158) (now merged), which added the chips. This targets `development` directly.

## Change

The `Group owner` / `Deposited` / `Not deposited` / `Claimed` chips move from just after the member name to a right-aligned group, sitting **16px from the accordion chevron**.

The header row is now `justify-between`: name on the left, chip group on the right. The shared `AccordionTrigger` already puts a `gap-2.5` (10px) between its content and the chevron — I left that untouched so the join and stack-result accordions are unaffected — so the chip group carries a 6px right margin (`mr-1.5`) to total 16px.

One file, presentational only: `src/app/stacks/[id]/_components/members-info.tsx`.

## Verification

`tsc --noEmit`, `next lint` (on the file), and Prettier all pass. Not run in a browser locally (no env/Docker here) — the Netlify deploy preview on this PR is the visual check. Please confirm the 16px gap and right alignment look right against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
