### PR TITLE
feat(account): pending claims row + auto-claim-all toggle

### DIFF
--- a/src/app/account/_components/account-automatic-claims.tsx
+++ b/src/app/account/_components/account-automatic-claims.tsx
@@ -2,12 +2,9 @@
 
 import { Switch } from "@/components/switch";
 import { useModal } from "@/components/modal/context";
-import { automaticSavingCirclesAbi } from "@/lib/abis/automatic-saving-circles";
-import { AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
-import { getDefaultChainId } from "@/utils/chain";
+import { useAccountAutoClaimsState } from "@/hooks/use-account-auto-claims-state";
 import { Body } from "@breadcoop/ui";
 import { Address } from "viem";
-import { useReadContracts } from "wagmi";
 
 /**
  * Account-level "automatic claims" toggle. Reflects the aggregate state across
@@ -24,24 +21,12 @@ export function AccountAutomaticClaims({
   circleIds: bigint[];
 }) {
   const { setModal } = useModal();
-
-  const { data, isFetching } = useReadContracts({
-    contracts: circleIds.map((circleId) => ({
-      abi: automaticSavingCirclesAbi,
-      address: AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS,
-      functionName: "isAutomaticClaimsEnabled" as const,
-      args: [circleId, address] as const,
-      chainId: getDefaultChainId(),
-    })),
-    query: { enabled: circleIds.length > 0 },
-  });
+  const { enabledByIndex, allEnabled, isFetching } = useAccountAutoClaimsState(
+    address,
+    circleIds
+  );
 
   if (circleIds.length === 0) return null;
-
-  const enabledByIndex = circleIds.map(
-    (_, i) => data?.[i]?.status === "success" && data[i].result === true
-  );
-  const allEnabled = enabledByIndex.every(Boolean);
 
   const onToggle = () => {
     const target = !allEnabled;

--- a/src/app/account/_components/account-automatic-claims.tsx
+++ b/src/app/account/_components/account-automatic-claims.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Switch } from "@/components/switch";
+import { useModal } from "@/components/modal/context";
+import { automaticSavingCirclesAbi } from "@/lib/abis/automatic-saving-circles";
+import { AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
+import { getDefaultChainId } from "@/utils/chain";
+import { Body } from "@breadcoop/ui";
+import { Address } from "viem";
+import { useReadContracts } from "wagmi";
+
+/**
+ * Account-level "automatic claims" toggle. Reflects the aggregate state across
+ * the user's current stacks — on only when every stack has it enabled — and
+ * flipping it opens a confirmation modal that updates each stack (one tx per
+ * stack, only the ones that need changing). There is no account-level contract
+ * flag, so this cannot affect stacks the user joins later.
+ */
+export function AccountAutomaticClaims({
+  address,
+  circleIds,
+}: {
+  address: Address;
+  circleIds: bigint[];
+}) {
+  const { setModal } = useModal();
+
+  const { data, isFetching } = useReadContracts({
+    contracts: circleIds.map((circleId) => ({
+      abi: automaticSavingCirclesAbi,
+      address: AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS,
+      functionName: "isAutomaticClaimsEnabled" as const,
+      args: [circleId, address] as const,
+      chainId: getDefaultChainId(),
+    })),
+    query: { enabled: circleIds.length > 0 },
+  });
+
+  if (circleIds.length === 0) return null;
+
+  const enabledByIndex = circleIds.map(
+    (_, i) => data?.[i]?.status === "success" && data[i].result === true
+  );
+  const allEnabled = enabledByIndex.every(Boolean);
+
+  const onToggle = () => {
+    const target = !allEnabled;
+    // Only touch stacks whose current state differs from the target.
+    const toChange = circleIds.filter((_, i) => enabledByIndex[i] !== target);
+    if (toChange.length === 0) return;
+    setModal({
+      type: "AUTOMATIC_CLAIMS_ALL",
+      circleIds: toChange,
+      enabling: target,
+    });
+  };
+
+  return (
+    <label className="flex items-center gap-2">
+      <Body className="text-surface-grey">Auto-claim all</Body>
+      <Switch
+        id="account-automatic-claims"
+        checked={allEnabled}
+        disabled={isFetching}
+        onCheckedChange={onToggle}
+      />
+    </label>
+  );
+}

--- a/src/app/account/_components/account-balance-card.tsx
+++ b/src/app/account/_components/account-balance-card.tsx
@@ -14,6 +14,7 @@ import {
 import Link from "next/link";
 import { Address, formatEther } from "viem";
 import { AccountAutomaticClaims } from "./account-automatic-claims";
+import { useAccountAutoClaimsState } from "@/hooks/use-account-auto-claims-state";
 
 // Circle-lifecycle statuses where auto-claims no longer apply (nothing left to
 // claim), so they're excluded from the account-level toggle.
@@ -35,6 +36,23 @@ const AccountBalanceCard = ({
   const { setModal } = useModal();
   const isOwner = useIsOwnAddress(address);
   const { circles, financialSummary, isLoading } = useUserCirclesList(address);
+
+  // Stacks the user is still in (not yet finished/failed/expired) — the ones the
+  // account-level auto-claims toggle can act on. Derived before the early return
+  // so the hook below keeps a stable call order.
+  const activeMemberCircleIds = circles
+    .filter(
+      (circle) =>
+        circle.isMember && !TERMINAL_STATUSES.includes(circle.status ?? "")
+    )
+    .map((circle) => circle.id);
+
+  // Aggregate auto-claim state, shared with the toggle: when every stack already
+  // auto-claims, the bulk-claim shortcut is redundant.
+  const { allEnabled: allAutoClaimsEnabled } = useAccountAutoClaimsState(
+    address,
+    activeMemberCircleIds
+  );
 
   const scrollToStacks = () => {
     document
@@ -67,14 +85,11 @@ const AccountBalanceCard = ({
     0
   );
 
-  // Stacks the user is still in (not yet finished/failed/expired), which are the
-  // ones the account-level auto-claims toggle can act on.
-  const activeMemberCircleIds = circles
-    .filter(
-      (circle) =>
-        circle.isMember && !TERMINAL_STATUSES.includes(circle.status ?? "")
-    )
-    .map((circle) => circle.id);
+  const claimableCount = circles.filter((circle) => circle.canWithdraw).length;
+
+  // The bulk-claim shortcut only helps when payouts are waiting in more than one
+  // stack and auto-claims isn't already covering every stack.
+  const canBulkClaim = claimableCount > 1 && !allAutoClaimsEnabled;
 
   return (
     <div className={`flex flex-col gap-6 ${cardClass}`}>
@@ -136,7 +151,7 @@ const AccountBalanceCard = ({
                   circleIds={activeMemberCircleIds}
                 />
               )}
-              {pendingClaims > 0 ? (
+              {canBulkClaim ? (
                 <LocalButton
                   as={Link}
                   href={`${basePath}?tab=claim`}

--- a/src/app/account/_components/account-balance-card.tsx
+++ b/src/app/account/_components/account-balance-card.tsx
@@ -6,9 +6,18 @@ import { useModal } from "@/components/modal/context";
 import { useIsOwnAddress } from "@/hooks/use-is-own-address";
 import { useUserCirclesList } from "@/hooks/use-user-circles-list";
 import { Body, Caption, Heading2, formatBalance } from "@breadcoop/ui";
-import { CoinsIcon, HandDepositIcon } from "@phosphor-icons/react";
+import {
+  CoinsIcon,
+  HandDepositIcon,
+  HandWithdrawIcon,
+} from "@phosphor-icons/react";
 import Link from "next/link";
 import { Address, formatEther } from "viem";
+import { AccountAutomaticClaims } from "./account-automatic-claims";
+
+// Circle-lifecycle statuses where auto-claims no longer apply (nothing left to
+// claim), so they're excluded from the account-level toggle.
+const TERMINAL_STATUSES = ["decommissioned", "expired", "failed", "finished"];
 
 const toBread = (value: bigint | undefined) =>
   Number(formatEther(value ?? BigInt(0)));
@@ -49,6 +58,23 @@ const AccountBalanceCard = ({
         : sum,
     0
   );
+
+  // `withdrawAmount` is already denominated in BREAD and only present when the
+  // member can currently claim that circle's payout.
+  const pendingClaims = circles.reduce(
+    (sum, circle) =>
+      circle.canWithdraw ? sum + (circle.withdrawAmount ?? 0) : sum,
+    0
+  );
+
+  // Stacks the user is still in (not yet finished/failed/expired), which are the
+  // ones the account-level auto-claims toggle can act on.
+  const activeMemberCircleIds = circles
+    .filter(
+      (circle) =>
+        circle.isMember && !TERMINAL_STATUSES.includes(circle.status ?? "")
+    )
+    .map((circle) => circle.id);
 
   return (
     <div className={`flex flex-col gap-6 ${cardClass}`}>
@@ -95,6 +121,44 @@ const AccountBalanceCard = ({
       {/* Pending actions */}
       <div className="flex flex-col gap-4">
         <Heading2 className="text-xl">Pending actions</Heading2>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <Body className="text-surface-grey">Pending claims</Body>
+            <p className="text-2xl font-bold text-system-green">
+              ${formatBalance(pendingClaims, 2)}
+            </p>
+          </div>
+          {isOwner && (
+            <div className="flex flex-wrap items-center gap-3">
+              {activeMemberCircleIds.length > 0 && (
+                <AccountAutomaticClaims
+                  address={address}
+                  circleIds={activeMemberCircleIds}
+                />
+              )}
+              {pendingClaims > 0 ? (
+                <LocalButton
+                  as={Link}
+                  href={`${basePath}?tab=claim`}
+                  scroll={false}
+                  onClick={scrollToStacks}
+                  className="font-bold"
+                  leftIcon={<HandWithdrawIcon />}
+                >
+                  Claim funds
+                </LocalButton>
+              ) : (
+                <LocalButton
+                  disabled
+                  className="font-bold opacity-50"
+                  leftIcon={<HandWithdrawIcon />}
+                >
+                  Claim funds
+                </LocalButton>
+              )}
+            </div>
+          )}
+        </div>
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex flex-col gap-1">
             <Body className="text-surface-grey">Pending deposits</Body>

--- a/src/components/claim-button.tsx
+++ b/src/components/claim-button.tsx
@@ -51,6 +51,9 @@ const ClaimButton = ({
 
       queryClient.invalidateQueries({ queryKey: ["readContract"] });
       queryClient.invalidateQueries({ queryKey: ["readContracts"] });
+      // Surface the withdrawal in the account history section without waiting
+      // for its 60s stale window.
+      queryClient.invalidateQueries({ queryKey: ["accountHistory"] });
 
       setModal({
         type: "CLAIM_RESULT",

--- a/src/components/modal/context.tsx
+++ b/src/components/modal/context.tsx
@@ -12,6 +12,7 @@ import { PeerExtensionSdk } from "@zkp2p/sdk";
 import { Address } from "viem";
 import { FundWithConnectedWalletModalAmountModalState } from "./modals/fund-wallet/fund-with-connected-wallet-modal-amount";
 import { AutomaticClaimsModalState } from "./modals/automatic-claims";
+import { AutomaticClaimsAllModalState } from "./modals/automatic-claims-all";
 import type { AutomaticDepositsModalState } from "@/components/automatic-deposits/types";
 
 export type TModalStatus = "loading" | "success" | "error";
@@ -158,6 +159,7 @@ export type ModalState =
   | PeerOnRampInstallModalState
   | FundWithConnectedWalletModalAmountModalState
   | AutomaticClaimsModalState
+  | AutomaticClaimsAllModalState
   | VisitorOnboardingModalState
   | AutomaticDepositsModalState
   | null;

--- a/src/components/modal/modals/automatic-claims-all.tsx
+++ b/src/components/modal/modals/automatic-claims-all.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  ModalCloseIcon,
+  ModalContainer,
+  ModalHeader,
+  ModalStatus,
+} from "../components";
+import { Body, Heading3 } from "@breadcoop/ui";
+import { HandWithdrawIcon } from "@phosphor-icons/react";
+import { useModal } from "../context";
+import { useAccountAutomaticClaims } from "@/hooks/use-account-automatic-claims";
+import LocalLiftedButton from "@/components/button";
+
+export interface AutomaticClaimsAllModalState {
+  type: "AUTOMATIC_CLAIMS_ALL";
+  // Circles that actually need changing (already-matching stacks are excluded
+  // by the toggle so they cost no transaction).
+  circleIds: bigint[];
+  enabling: boolean;
+}
+
+const AutomaticClaimsAllModal = ({
+  modalState: { circleIds, enabling },
+}: {
+  modalState: AutomaticClaimsAllModalState;
+}) => {
+  const modal = useModal();
+  const { setAllEnabled, status, setStatus, progress } =
+    useAccountAutomaticClaims();
+
+  const closeModal = () => modal.setModal(null);
+  const count = circleIds.length;
+
+  return (
+    <ModalContainer
+      status={
+        status === "idle"
+          ? undefined
+          : status === "loading"
+            ? "loading"
+            : status
+      }
+    >
+      {status !== "idle" ? (
+        <>
+          <ModalHeader
+            title={`Automatic claims ${status === "success" ? "updated" : status === "error" ? "failed" : ""}`}
+          />
+          <ModalStatus
+            status={status}
+            statusMsg={
+              status === "success"
+                ? `Automatic claims ${enabling ? "activated" : "deactivated"} on ${progress.done - progress.failed} of ${progress.total} stacks.`
+                : status === "error"
+                  ? "Transaction failed"
+                  : `Confirm each transaction in your wallet (${progress.done} of ${progress.total})`
+            }
+          />
+          <Body
+            bold={status === "error"}
+            className={`text-center ${status === "success" ? "text-surface-grey" : "text-surface-grey-2"}`}
+          >
+            {status === "success"
+              ? progress.failed > 0
+                ? `${progress.failed} stack${progress.failed === 1 ? "" : "s"} could not be updated. You can try again.`
+                : enabling
+                  ? "Your funds will be sent to your wallet automatically when it's your turn to claim."
+                  : "Automatic claims have been turned off for your stacks."
+              : status === "error"
+                ? "Something went wrong. Please try again!"
+                : ""}
+          </Body>
+          {status === "success" ? (
+            <div className="lifted-button-container">
+              <LocalLiftedButton onClick={closeModal}>Done</LocalLiftedButton>
+            </div>
+          ) : status === "error" ? (
+            <LocalLiftedButton
+              variant="destructive"
+              className="lifted-button-container"
+              onClick={() => setStatus("idle")}
+            >
+              Try again
+            </LocalLiftedButton>
+          ) : null}
+        </>
+      ) : (
+        <div className="flex flex-col items-center justify-center text-center">
+          <button
+            type="button"
+            onClick={closeModal}
+            className="inline-block ml-auto"
+          >
+            <ModalCloseIcon />
+          </button>
+          <HandWithdrawIcon size={48} />
+          <Heading3 className="text-2xl mt-3 mb-6">
+            {enabling ? "Activate" : "Deactivate"} automatic claims
+          </Heading3>
+          <Body bold className="mb-6 text-surface-grey-2">
+            {enabling
+              ? "Send funds to your wallet automatically"
+              : "Stop automatic fund transfers"}
+          </Body>
+          <Body className="mb-6 text-surface-grey">
+            {`This will ${enabling ? "activate" : "deactivate"} automatic claims across ${count} of your stacks, one transaction each.`}
+          </Body>
+          <div className="lifted-button-container">
+            <LocalLiftedButton
+              onClick={() => setAllEnabled(circleIds, enabling)}
+            >
+              {enabling ? "Activate" : "Deactivate"} on {count} stack
+              {count === 1 ? "" : "s"}
+            </LocalLiftedButton>
+          </div>
+        </div>
+      )}
+    </ModalContainer>
+  );
+};
+
+export default AutomaticClaimsAllModal;

--- a/src/components/modal/presenter.tsx
+++ b/src/components/modal/presenter.tsx
@@ -23,6 +23,7 @@ import InstallPeerModal from "../peer/install-modal";
 import FundWithConnectedWalletModalAmount from "./modals/fund-wallet/fund-with-connected-wallet-modal-amount";
 import StartStackWarningModal from "./modals/start-stack-warning";
 import AutomaticClaimsModal from "./modals/automatic-claims";
+import AutomaticClaimsAllModal from "./modals/automatic-claims-all";
 import VisitorOnboarding from "../onboard/visitor-onboard-modal";
 import AutomaticDepositsModal from "@/components/automatic-deposits/modal";
 
@@ -99,6 +100,9 @@ const ModalPresenter = () => {
               )}
               {modalState.type === "AUTOMATIC_CLAIMS" && (
                 <AutomaticClaimsModal modalState={modalState} />
+              )}
+              {modalState.type === "AUTOMATIC_CLAIMS_ALL" && (
+                <AutomaticClaimsAllModal modalState={modalState} />
               )}
               {modalState.type === "VISITOR_ONBOARDING" && (
                 <VisitorOnboarding />

--- a/src/hooks/use-account-auto-claims-state.ts
+++ b/src/hooks/use-account-auto-claims-state.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { automaticSavingCirclesAbi } from "@/lib/abis/automatic-saving-circles";
+import { AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS } from "@/lib/constants";
+import { getDefaultChainId } from "@/utils/chain";
+import { Address } from "viem";
+import { useReadContracts } from "wagmi";
+
+/**
+ * Reads whether automatic claims are enabled for each of the given stacks and
+ * derives the aggregate state. Shared by the account-level toggle and the
+ * bulk-claim button so both read from one (TanStack-deduped) query.
+ *
+ * `allEnabled` is true only when there's at least one stack and every one has
+ * auto-claims on — that's the case where the bulk-claim shortcut is redundant.
+ */
+export function useAccountAutoClaimsState(
+  address: Address,
+  circleIds: bigint[]
+) {
+  const { data, isFetching } = useReadContracts({
+    contracts: circleIds.map((circleId) => ({
+      abi: automaticSavingCirclesAbi,
+      address: AUTOMATIC_SAVING_CIRCLES_CONTRACT_ADDRESS,
+      functionName: "isAutomaticClaimsEnabled" as const,
+      args: [circleId, address] as const,
+      chainId: getDefaultChainId(),
+    })),
+    query: { enabled: circleIds.length > 0 },
+  });
+
+  const enabledByIndex = circleIds.map(
+    (_, i) => data?.[i]?.status === "success" && data[i].result === true
+  );
+  const allEnabled = circleIds.length > 0 && enabledByIndex.every(Boolean);
+
+  return { enabledByIndex, allEnabled, isFetching };
+}

--- a/src/hooks/use-account-automatic-claims.ts
+++ b/src/hooks/use-account-automatic-claims.ts
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAutomaticSavingCirclesTx } from "./use-automatic-saving-circles-tx";
+
+export type AccountAutomaticClaimsStatus =
+  | "idle"
+  | "loading"
+  | "success"
+  | "error";
+
+export interface AccountAutomaticClaimsProgress {
+  done: number;
+  total: number;
+  failed: number;
+}
+
+/**
+ * Account-level auto-claims: enable/disable automatic claims across every stack
+ * the user is currently in. The contract has no batch setter and no
+ * account-level flag, so this loops `setAutomaticClaimsEnabled` one stack at a
+ * time. Callers pass only the circles that actually need changing (those whose
+ * current state differs from the target), so already-matching stacks cost no
+ * transaction. Failures don't abort the run — each stack is independent — and
+ * the final status reflects whether any succeeded.
+ */
+export function useAccountAutomaticClaims() {
+  const { sendAutomaticSavingCirclesTx } = useAutomaticSavingCirclesTx();
+  const { user: privyUser } = usePrivy();
+  const [status, setStatus] = useState<AccountAutomaticClaimsStatus>("idle");
+  const [progress, setProgress] = useState<AccountAutomaticClaimsProgress>({
+    done: 0,
+    total: 0,
+    failed: 0,
+  });
+  const queryClient = useQueryClient();
+
+  const setAllEnabled = async (circleIds: bigint[], enabled: boolean) => {
+    if (status === "loading" || !privyUser?.id || circleIds.length === 0)
+      return;
+
+    setStatus("loading");
+    setProgress({ done: 0, total: circleIds.length, failed: 0 });
+
+    let failed = 0;
+    for (let i = 0; i < circleIds.length; i++) {
+      try {
+        await sendAutomaticSavingCirclesTx({
+          functionName: "setAutomaticClaimsEnabled",
+          args: [circleIds[i], enabled],
+        });
+      } catch (err) {
+        console.error(
+          "useAccountAutomaticClaims error for circle",
+          circleIds[i].toString(),
+          err
+        );
+        failed++;
+      }
+      setProgress({ done: i + 1, total: circleIds.length, failed });
+    }
+
+    // Refresh the per-circle `isAutomaticClaimsEnabled` reads that drive the
+    // toggle's aggregate state.
+    queryClient.invalidateQueries({ queryKey: ["readContract"] });
+    queryClient.invalidateQueries({ queryKey: ["readContracts"] });
+
+    setStatus(failed === circleIds.length ? "error" : "success");
+  };
+
+  return { setAllEnabled, status, setStatus, progress };
+}


### PR DESCRIPTION
Adds a **Pending claims** row to the account page's "Pending actions" section (above Pending deposits), plus an account-level auto-claims toggle.

## What's included

- **Pending claims amount** — total currently-claimable BREAD across the user's stacks, in green. Computed client-side by summing each stack's `withdrawAmount` where `canWithdraw` (the viewer's `pendingWithdrawals` is a *count* of claimable stacks, not an amount).
- **"Claim funds" button** — a shortcut that scrolls to the `claim` tab (`?tab=claim` + smooth-scroll to `#your-stacks`). Enabled **only** when payouts are waiting in **more than one** stack *and* auto-claims isn't already on for every stack (where it'd be redundant); disabled otherwise. **It does not bulk-claim yet** — see below.
- **Auto-claim-all toggle** — next to the button. Reflects the aggregate state across the user's current stacks (on only when every stack has it enabled). Flipping it opens a confirmation modal that updates each stack that needs changing, one transaction per stack.
- **History** — claims already appear in the Account history card (it reads `FundsWithdrawn` events). This just invalidates that query on claim so a fresh withdrawal shows immediately instead of after its 60s stale window.

Owner-only (gated on `isOwnAddress`), matching the existing Deposit/Withdraw actions.

## Deliberately *not* a bulk claim — and why

The "ideal" one-click claim-from-all-stacks is **not possible on-chain today**: `withdraw` is per-circle, and the only batch function (`batchExecuteAutomatedClaims`) is `OnlyAutomationExecutor`. So this PR ships the front-end shortcut (scroll to the claim tab, claim per stack) and defers the real bulk claim to a contract change — tracked in the follow-up issue below.

Same constraint applies to the toggle: there's no account-level auto-claims flag or batch setter, so "all stacks" means "each of your current stacks, one tx each," and it can't auto-enroll stacks you join later. The confirmation modal states the stack count up front.

Follow-up contract issue: https://github.com/BreadchainCoop/saving-circles/issues/191

## Files

- `account-balance-card.tsx` — the Pending claims row.
- `account-automatic-claims.tsx` (new) — the aggregate toggle.
- `use-account-automatic-claims.ts` (new) — the per-stack update loop with progress.
- `modals/automatic-claims-all.tsx` (new) + `context.tsx` / `presenter.tsx` — the confirmation/progress modal.
- `claim-button.tsx` — invalidate `accountHistory` on claim.

## Verification

`tsc --noEmit`, `next lint`, and Prettier pass. Not run in a browser locally (no env/Docker here) — the Netlify preview is the visual check. Please verify against a live account with claimable stacks:

- the green Pending claims amount matches what the claim tab shows
- "Claim funds" scrolls to the claim tab and is disabled at $0.00
- toggling Auto-claim-all fires one tx per current stack and settles to the right aggregate state
- a manual claim shows up in Account history without a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
